### PR TITLE
feat(core): Add videos missing from previous execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ specific playlist
   selection of music channels.
 - [📡 RELEASE RADAR](https://www.youtube.com/playlist?list=PLOMUdQFdS-XNe56Ot6KQmsR4cLT2ua9IC): regular music releases 
   among my subscriptions.
-- [⏳ Watch Later 2K24](https://www.youtube.com/playlist?list=PLOMUdQFdS-XPfjAeBp5TuNDQmMoiJHdvB): other type of video to Watch Later (since regular Watch Later playlist can't be 
+- [⏳ Watch Later 2K24](https://www.youtube.com/playlist?list=PLOMUdQFdS-XPfjAeBp5TuNDQmMoiJHdvB) (Private): other type of video to Watch Later (since regular Watch Later playlist can't be 
   manipulated with the API).
 
 This project follows up the developments made in the [Automated YouTube Playlist](https://github.com/Dyl-M/auto_youtube_playlist) 
@@ -42,6 +42,7 @@ comprehension or workflow execution.
 │
 ├── data
 │   ├── add-on.json
+│   ├── api_failure.json
 │   ├── playlists.json
 │   ├── pocket_tube.json
 │   └── stats.csv

--- a/data/api_failure.json
+++ b/data/api_failure.json
@@ -1,0 +1,23 @@
+{
+  "PLOMUdQFdS-XNe56Ot6KQmsR4cLT2ua9IC": {
+    "name": "Release Radar",
+    "description": "Music release radar based on my YouTube subscriptions.",
+    "failure": []
+  },
+  "PLOMUdQFdS-XOI8OIWV_Gx-SRhlCS9PKLn": {
+    "name": "Banger Radar",
+    "description": "Music release radar based on my YouTube subscriptions. Absolute. Priority.",
+    "failure": []
+  },
+  "PLOMUdQFdS-XPfjAeBp5TuNDQmMoiJHdvB": {
+    "name": "Watch Later",
+    "description": "2024 videos to watch later.",
+    "failure": [
+      "k-Gnb1XvS5k",
+      "XM9IdObhIWs",
+      "MYNKUtgYBBQ",
+      "SnXc02jzpKI",
+      "AUxZiIXU8j0"
+    ]
+  }
+}

--- a/src/main.py
+++ b/src/main.py
@@ -150,6 +150,9 @@ if __name__ == '__main__':
         YOUTUBE_OAUTH, CREDS_B64 = youtube.create_service_workflow()
         PROG_BAR = False  # Do not display progress bar
 
+    # Add missing videos due to quota exceeded on previous run
+    youtube.add_api_fail(service=YOUTUBE_OAUTH, prog_bar=PROG_BAR)
+
     # Search for new videos to add
     history_main.info('Iterative research for %s YouTube channels.', len(all_channels))
     new_videos = youtube.iter_channels(YOUTUBE_OAUTH, all_channels, prog_bar=PROG_BAR)


### PR DESCRIPTION
* api_failure.json: videos not added due to API error (by destination playlist)
* `add_api_fail`: to execute at the start of the process, add every video missing due to API error (mostly due to quota limit) to their targeted playlist.
* `add_to_playlist`: changed to include API error
* README updated