### PR TITLE
deps(python): rollback google-auth to 2.41.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 /cmd/
 gha-creds-*.json
 /archive/
+
+# Claude.ai
+CLAUDE.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4~=4.14.2
 google-api-python-client~=2.186.0
-google-auth~=2.42.1
+google-auth~=2.41.1
 google-auth-oauthlib~=1.2.3
 isodate~=0.7.2
 numpy~=2.3.4


### PR DESCRIPTION
Rolled back google-auth from 2.42.1 to 2.41.1 and updated .gitignore to exclude CLAUDE.md.

Caused by an [incompatibility](https://github.com/Dyl-M/youtube_release_tracker/actions/runs/19012163449) between : 

- google-auth - 2.42.1
- google-api-python-client - 2.186.0
- google-auth-oauthlib - 1.2.3

Temporary fix while waiting for a response from Google...
