### PR TITLE
Fix: Workflow Runs Before API Quota Reset

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -9,7 +9,7 @@ on:
                 default: 'warning'
 
     schedule:
-        -   cron: "0 7 * * *"  # Runs at 7:00 AM UTC, which aligns with midnight PST outside of daylight saving time
+        -   cron: "0 7 * * *"  # Runs at 7:00 AM UTC, waits until midnight PT (auto-adjusts for PST/PDT)
 
 jobs:
     build-linux:
@@ -42,39 +42,28 @@ jobs:
                 name: Set Up Timezone
                 if: env.proceed_with_check == 'true'
                 run: |
-                    # Install timezone data and set the timezone to America/Los_Angeles
+                    # Install timezone data
                     sudo apt-get update && sudo apt-get install -y tzdata
-                    export TZ="America/Los_Angeles"
-                    echo "Timezone set to America/Los_Angeles" 
+                    echo "Timezone data installed"
 
             -   id: wait-0000-pst
-                name: Wait Until Midnight PST
+                name: Wait Until Midnight PT (PST/PDT)
                 if: env.proceed_with_check == 'true'
                 run: |
                     while true; do
-                      # Get the current hour and minute in the specified timezone
-                      current_hour=$(date +'%H')
-                      current_minute=$(date +'%M')
-                    
-                      # Check if the current time is midnight or past midnight
-                      if [ "$current_hour" -eq "00" ] && [ "$current_minute" -eq "00" ]; then
-                        echo "It's midnight PST! Proceeding with the task."
-                        break
-                      elif [ "$current_hour" -gt "00" ] || ([ "$current_hour" -eq "00" ] && [ "$current_minute" -gt "00" ]); then
-                        echo "The current time is past midnight PST. Proceeding without waiting."
+                      # Get the current hour and minute in Pacific Time (handles PST/PDT automatically)
+                      current_hour=$(TZ="America/Los_Angeles" date +'%H')
+                      current_minute=$(TZ="America/Los_Angeles" date +'%M')
+
+                      # Check if it's midnight hour (00:00-00:59) or later
+                      if [ "$current_hour" -eq 0 ]; then
+                        echo "It's midnight PT or later! Current time: $current_hour:$current_minute PT. Proceeding."
                         break
                       else
-                        echo "It's not midnight PST yet. Current time: $current_hour:$current_minute. Waiting..."
+                        echo "Not midnight PT yet. Current time: $current_hour:$current_minute PT. Waiting..."
                         sleep 60 # Wait for 1 minute before checking again
                       fi
                     done
-
-            -   id: tz-reset
-                name: Reset Timezone to UTC
-                if: env.proceed_with_check == 'true'
-                run: |
-                    export TZ="UTC"
-                    echo "Timezone reset to UTC"
 
             -   id: git-checkout
                 name: Checkout repository


### PR DESCRIPTION
## Summary

Fixes issue #116 where the GitHub Actions workflow executes before midnight PT, causing `quotaExceeded` errors because the YouTube Data API v3 quota hasn't reset yet.

## Problem

The scheduled workflow was hitting quota limits despite running daily. Analysis of `log/last_exe.log` revealed:

```
2025-11-06 07:13:28+0000 [INFO] - Process started.
...
2025-11-06 07:16:53+0000 [WARNING] - Addition Request Failure: (RiXbhfHKpiU) - quotaExceeded
```

**Root causes:**

1. **Incorrect waiting logic** (`.github/workflows/main_workflow.yml:59`):
   - Previous condition: `if [ "$current_hour" -gt "00" ]`
   - At 11 PM PST (hour = 23), this evaluates to true (23 > 0)
   - Workflow proceeded immediately instead of waiting until midnight
   - Script ran at 11 PM PST, one hour BEFORE quota reset

2. **Timezone persistence issue**:
   - Used `export TZ="America/Los_Angeles"` which doesn't persist across GitHub Actions steps
   - Each step runs in a new shell, losing the timezone setting
   - `date` commands in wait loop used wrong timezone

## Solution

### Fixed Waiting Logic

Changed condition to explicitly check for midnight hour:

```bash
# Old (broken)
if [ "$current_hour" -gt "00" ] || ...; then
  break  # Would break at 11 PM (23 > 0)
fi

# New (fixed)
if [ "$current_hour" -eq 0 ]; then
  break  # Only breaks during 00:00-00:59 PT
fi
```

### Fixed Timezone Handling

Use inline timezone with `date` command:

```bash
# Old (doesn't persist)
export TZ="America/Los_Angeles"
current_hour=$(date +'%H')

# New (works correctly)
current_hour=$(TZ="America/Los_Angeles" date +'%H')
```

### Behavior After Fix

- **During PDT** (March-November): 7 AM UTC = midnight PDT → proceeds immediately
- **During PST** (November-March): 7 AM UTC = 11 PM PST → waits ~1 hour until midnight
- **Quota reset**: Midnight PT (YouTube API resets at 12:00 AM Pacific)
- **Script execution**: Always runs at or after 00:00 PT

## Changes

- `.github/workflows/main_workflow.yml`:
  - Fixed midnight waiting condition (line 59)
  - Fixed timezone handling with inline `TZ` (lines 55-56)
  - Removed unnecessary `tz-reset` step (lines 72-77)
  - Updated comments to reflect PST/PDT auto-adjustment