### PR TITLE
fix(youtube): filter out videos without release date (#104)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -105,15 +105,23 @@ def dest_playlist(channel_id: str, is_shorts: bool, v_duration: int, max_duratio
     if is_shorts:
         return 'shorts'
 
-    if channel_id in music:
-        if v_duration > max_duration * 60:
-            if channel_id in other:
-                return watch_later
-            return 'none'
-        if channel_id in favorites:
-            return banger
-        return release
-    return watch_later
+    is_music_channel = channel_id in music
+    is_long_video = v_duration > max_duration * 60
+
+    # Non-music channels -> Watch Later
+    if not is_music_channel:
+        return watch_later
+
+    # Long music videos -> Watch Later (if also in other categories) or skip
+    if is_long_video:
+        return watch_later if channel_id in other else 'none'
+
+    # Short music videos from favorites -> Banger Radar
+    if channel_id in favorites:
+        return banger
+
+    # Regular short music videos -> Release Radar
+    return release
 
 
 def update_repo_secrets(secret_name: str, new_value: str, logger: logging.Logger = None):

--- a/src/youtube.py
+++ b/src/youtube.py
@@ -254,14 +254,15 @@ def get_playlist_items(service: pyt.Client, playlist_id: str, day_ago: int = Non
                                                  max_results=50,
                                                  pageToken=next_page_token)  # Request playlist's items
 
-            # Keep necessary data
+            # Keep necessary data, filtering out scheduled/premiere videos without release date
             p_items += [{'video_id': item.contentDetails.videoId,
                          'video_title': item.snippet.title,
                          'item_id': item.id,
                          'release_date': dt.datetime.strptime(item.contentDetails.videoPublishedAt, date_format),
                          'status': item.status.privacyStatus,
                          'channel_id': item.snippet.videoOwnerChannelId,
-                         'channel_name': item.snippet.videoOwnerChannelTitle} for item in request.items]
+                         'channel_name': item.snippet.videoOwnerChannelTitle}
+                        for item in request.items if item.contentDetails.videoPublishedAt is not None]
 
             p_items = filter_items_by_date_range(p_items, latest_d, _oldest_d=oldest_d, _day_ago=day_ago)
             next_page_token = request.nextPageToken


### PR DESCRIPTION
## Summary

Fixes #104 - Handles rare case where videos have no release date (`videoPublishedAt` is `None`), causing a `TypeError` in `datetime.strptime()`.

### Changes

- **Filter scheduled/premiere videos**: Videos without `videoPublishedAt` are now filtered out in `get_playlist_items()` using a list comprehension condition
- **Refactor `dest_playlist()`**: Improved readability with flat structure, named boolean variables, and inline comments

### Root Cause

YouTube API returns `None` for `videoPublishedAt` on scheduled videos and premieres that haven't aired yet. These videos will be picked up automatically once they go live and have a proper release date.