### PR TITLE
fix: ISO8601 date parsing in weekly_stats

### DIFF
--- a/yrt/youtube/stats.py
+++ b/yrt/youtube/stats.py
@@ -138,7 +138,7 @@ def weekly_stats(
     x_week_ago = ref_date.replace(hour=0, minute=0, second=0, microsecond=0) - dt.timedelta(weeks=week_delta)
 
     # Filter data with this new reference date
-    histo_data['release_date'] = pd.to_datetime(histo_data.release_date)
+    histo_data['release_date'] = pd.to_datetime(histo_data.release_date, format='ISO8601')
     date_mask = (histo_data.release_date.dt.date == x_week_ago.date()) & (histo_data[f'views_w{week_delta}'].isnull())
     selection = histo_data[date_mask]
     id_mask = selection.video_id.tolist()


### PR DESCRIPTION
## Summary

Fixes the workflow failure reported in #142 by explicitly specifying ISO8601 format for date parsing in the `weekly_stats` function.

## Problem

The daily workflow failed with a `ValueError` when `pd.to_datetime()` attempted to parse dates from `stats.csv`:

```
ValueError: time data "2026-01-06T09:23:18+00:00" doesn't match format "%Y-%m-%d %H:%M:%S%z", at position 9699
```

The dates in `stats.csv` are stored in ISO8601 format with 'T' separator (e.g., `2026-01-06T09:23:18+00:00`), but pandas was failing to auto-detect this format.

## Solution

Add explicit `format='ISO8601'` parameter to `pd.to_datetime()` call in `weekly_stats()`:

```python
# Before
histo_data['release_date'] = pd.to_datetime(histo_data.release_date)

# After
histo_data['release_date'] = pd.to_datetime(histo_data.release_date, format='ISO8601')
```

This change only affects reading/parsing - the data saved to `stats.csv` remains unchanged.

## Changes

* `yrt/youtube/stats.py`: Add `format='ISO8601'` to `pd.to_datetime()` call in `weekly_stats()`

## Validation steps before merge

- [ ] DeepSource Health-Check OK (no regression)
- [ ] Tests/Coverage CI OK
- [ ] Human review completed (post-changes made by DeepSource or assisted tools)