### PR TITLE
fix: Remove redundant axis parameter (introduced by pandas 3.0)

### DIFF
--- a/yrt/youtube/stats.py
+++ b/yrt/youtube/stats.py
@@ -157,7 +157,7 @@ def weekly_stats(
         histo_data.loc[histo_data.video_id.isin(id_mask), [f'likes_w{week_delta}']] = histo_data.likes
         histo_data.loc[histo_data.video_id.isin(id_mask), [f'comments_w{week_delta}']] = histo_data.comments
         histo_data.loc[histo_data.video_id.isin(id_mask), ['status']] = histo_data.latest_status
-        histo_data.drop(columns=['views', 'likes', 'comments', 'latest_status'], axis=1, inplace=True)
+        histo_data.drop(columns=['views', 'likes', 'comments', 'latest_status'], inplace=True)
 
     else:
         if utils.history:


### PR DESCRIPTION
## Summary

Fixes a breaking change introduced by pandas 3.0 that caused the workflow to fail. The `DataFrame.drop()` method no longer accepts both `columns=` and `axis=` parameters simultaneously.

Closes #150

## Problem

The GitHub Actions workflow failed with:
```
ValueError: Cannot specify both 'axis' and 'index'/'columns'
```

This occurred in `yrt/youtube/stats.py:160` within the `weekly_stats()` function. Pandas 3.0 made the `axis` parameter redundant when using `columns=` (which already implies `axis=1`).

## Solution

Removed the redundant `axis=1` parameter from the `DataFrame.drop()` call:

```python
# Before (pandas 2.x compatible, breaks in 3.0)
histo_data.drop(columns=['views', 'likes', 'comments', 'latest_status'], axis=1, inplace=True)

# After (compatible with both pandas 2.x and 3.0)
histo_data.drop(columns=['views', 'likes', 'comments', 'latest_status'], inplace=True)
```

## Validation steps before merge

- [x] DeepSource Health-Check OK (no regression)
- [x] Tests/Coverage CI OK
- [x] Human review completed (post-changes made by DeepSource or assisted tools)
