### PR TITLE
chore: branch reorganization + codebase-wide lint/type tightening and fixes

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -29,8 +29,23 @@ jobs:
 
     steps:
       - id: git-checkout
-        name: Checkout repository
+        name: Checkout run branch
         uses: actions/checkout@v6
+        with:
+          ref: run
+          fetch-depth: 0
+
+      - id: sync-code
+        name: Sync code from main
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions"
+          git fetch origin main
+          git merge origin/main --no-edit || {
+            git checkout --ours -- _data/ _log/
+            git add -A
+            git commit --no-edit
+          }
 
       - id: uv-setup
         name: Set up uv
@@ -58,16 +73,11 @@ jobs:
 
       - id: commit
         name: Commit changes (Log and historical data)
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "github-actions"
-          git commit -m "log: Latest execution report." -a
+        run: git commit -m "log: Latest execution report." -a || echo "No changes to commit"
 
       - id: push
-        name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        name: Push changes to run branch
+        run: git push origin HEAD:run
 
       - id: notify-failure
         name: Create issue on workflow failure

--- a/.github/workflows/monthly_consolidation.yml
+++ b/.github/workflows/monthly_consolidation.yml
@@ -1,0 +1,37 @@
+name: YTB Tracker - Monthly Log Consolidation
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 12 1 * *"
+      timezone: "America/Los_Angeles"
+
+jobs:
+  consolidate:
+    name: squash-run-into-main
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - id: git-checkout
+        name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - id: consolidate
+        name: Squash run into main and reset run
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions"
+          git fetch origin run main
+          git checkout main
+          git merge --squash origin/run
+          MONTH=$(date -d "1 month ago" +'%Y-%m')
+          git diff --staged --quiet || git commit -m "log: Monthly execution report (${MONTH})."
+          git push origin main
+          git push --force origin main:run

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # YouTube Release Tracker
 
-[![Python 3.12](https://img.shields.io/badge/python-3.12-blue?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
-[![GitHub last commit](https://img.shields.io/github/last-commit/Dyl-M/youtube_release_tracker?label=Last%20commit&style=flat-square)](https://github.com/Dyl-M/youtube_release_tracker/commits/main)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/Dyl-M/youtube_release_tracker?label=Commit%20activity&style=flat-square)](https://github.com/Dyl-M/youtube_release_tracker/commits/main)
-[![GitHub stars](https://img.shields.io/github/stars/Dyl-M/youtube_release_tracker?style=flat-square)]()
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json&style=flat-square)](https://github.com/astral-sh/uv)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json&style=flat-square)](https://github.com/astral-sh/ruff)
 [![License](https://img.shields.io/github/license/Dyl-M/youtube_release_tracker?style=flat-square)](LICENSE)
 
-[![Tests](https://github.com/Dyl-M/youtube_release_tracker/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/Dyl-M/youtube_release_tracker/actions/workflows/test-coverage.yml)
+![Status](https://img.shields.io/badge/status-active-brightgreen?style=flat-square)
+[![Test & Coverage](https://img.shields.io/github/actions/workflow/status/Dyl-M/youtube_release_tracker/test-coverage.yml?label=Test%20%26%20Coverage&style=flat-square&logo=github-actions&logoColor=white)](https://github.com/Dyl-M/youtube_release_tracker/actions/workflows/test-coverage.yml)
 [![DeepSource](https://app.deepsource.com/gh/Dyl-M/youtube_release_tracker.svg/?label=active+issues&show_trend=true&token=WpKQsgGZsHi_FrteJ2YyUhQ_)](https://app.deepsource.com/gh/Dyl-M/youtube_release_tracker/)
 [![DeepSource](https://app.deepsource.com/gh/Dyl-M/youtube_release_tracker.svg/?label=code+coverage&show_trend=true&token=WpKQsgGZsHi_FrteJ2YyUhQ_)](https://app.deepsource.com/gh/Dyl-M/youtube_release_tracker/)
-
-[![Bluesky followers](https://img.shields.io/bluesky/followers/dyl-m.bsky.social?label=Bluesky)](https://bsky.app/profile/dyl-m.bsky.social)
 
 ![Repository illustration](_media/repo_illustration.png?raw=true "Repository illustration")
 
@@ -57,6 +55,14 @@ youtube_release_tracker/
 ├── _tests        # Pytest test suite, fixtures and shared configuration
 └── yrt           # Main application package (source code)
 ```
+
+Branches
+-------------
+
+- `main`: clean code reference (this branch). Receives code changes and a single squashed execution-log commit per
+  month.
+- `run`: execution branch where the daily automated process runs and commits its logs and statistics.
+- `dev`: integration branch for ongoing development.
 
 External information
 -------------

--- a/README.md
+++ b/README.md
@@ -45,92 +45,17 @@ Repository structure
 -------------
 
 ```
-├── .github
-│   ├── ISSUE_TEMPLATE
-│   │   ├── feature_request.yml
-│   │   └── issue_report.yml
-│   ├── workflows
-│   │   ├── claude.yml
-│   │   ├── licence_workflow.yml
-│   │   ├── main_workflow.yml
-│   │   └── test-coverage.yml
-│   └── dependabot.yml
-│
-├── _config
-│   ├── add-on.json
-│   ├── api_failure.json
-│   ├── constants.json
-│   ├── playlists.json
-│   └── pocket_tube.json
-│
-├── _data
-│   └── stats.csv
-│
-├── _docs
-│   ├── IMPROVEMENTS-2026.md
-│   └── notes.txt
-│
-├── _log
-│   ├── history.log
-│   └── last_exe.log
-│
-├── _media
-│   └── repo_illustration.png
-│
-├── _notebooks
-│   └── channels_reporting.ipynb
-│
-├── _scripts
-│   ├── __init__.py
-│   ├── archive_data.py
-│   └── sort_db.py
-│
-├── _tests
-│   ├── fixtures
-│   │   ├── sample_playlist_response.json
-│   │   └── sample_video_stats.json
-│   ├── __init__.py
-│   ├── conftest.py
-│   ├── README.md
-│   ├── test_config.py
-│   ├── test_constants.py
-│   ├── test_exceptions.py
-│   ├── test_file_utils.py
-│   ├── test_logging_utils.py
-│   ├── test_main.py
-│   ├── test_models.py
-│   ├── test_paths.py
-│   ├── test_router.py
-│   └── test_youtube.py
-│
-├── yrt
-│   ├── youtube
-│   │   ├── __init__.py
-│   │   ├── api.py
-│   │   ├── auth.py
-│   │   ├── cleanup.py
-│   │   ├── playlist.py
-│   │   ├── stats.py
-│   │   └── utils.py
-│   ├── __init__.py
-│   ├── analytics.py
-│   ├── config.py
-│   ├── constants.py
-│   ├── exceptions.py
-│   ├── file_utils.py
-│   ├── logging_utils.py
-│   ├── main.py
-│   ├── models.py
-│   ├── paths.py
-│   └── router.py
-│
-├── .deepsource.toml
-├── .gitignore
-├── LICENSE
-├── pyproject.toml
-├── pytest.ini
-├── README.md
-└── uv.lock
+youtube_release_tracker/
+├── .github       # GitHub Actions workflows, issue templates and Dependabot config
+├── _config       # JSON configuration: channels, playlists, favorites and constants
+├── _data         # Historical video statistics (stats.csv)
+├── _docs         # Project documentation and notes
+├── _log          # Execution logs (history.log, last_exe.log)
+├── _media        # Repository illustration and media assets
+├── _notebooks    # Reporting Jupyter notebooks and exported PDFs
+├── _scripts      # Standalone maintenance scripts (database sort, data archiving)
+├── _tests        # Pytest test suite, fixtures and shared configuration
+└── yrt           # Main application package (source code)
 ```
 
 External information

--- a/_notebooks/channels_reporting.ipynb
+++ b/_notebooks/channels_reporting.ipynb
@@ -428,19 +428,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": [
-    "nv_95 = float(metrics.n_videos.quantile(0.95))\n",
-    "nvf_95 = float(metrics.n_videos_fil.quantile(0.95))\n",
-    "dw_95 = float(metrics.date_weight.quantile(0.95))\n",
-    "dwf_95 = float(metrics.date_weight_fil.quantile(0.95))\n",
-    "\n",
-    "favorites = metrics.loc[(metrics['n_videos'] >= nv_95) &\n",
-    "                        (metrics['n_videos_fil'] >= nvf_95) &\n",
-    "                        (metrics['date_weight'] >= dw_95) &\n",
-    "                        (metrics['date_weight_fil'] >= dwf_95), :]\n",
-    "\n",
-    "print(favorites[['channel_name', 'channel_id']])"
-   ],
+   "source": "nv_95 = float(metrics.n_videos.quantile(0.95))\nnvf_95 = float(metrics.n_videos_fil.quantile(0.95))\ndw_95 = float(metrics.date_weight.quantile(0.95))\ndwf_95 = float(metrics.date_weight_fil.quantile(0.95))\n\nfavorites = metrics.loc[(metrics['n_videos'] >= nv_95) &\n                        (metrics['n_videos_fil'] >= nvf_95) &\n                        (metrics['date_weight'] >= dw_95) &\n                        (metrics['date_weight_fil'] >= dwf_95), :]\n\nfavorites[['channel_name', 'channel_id']]",
    "id": "87067aa23493af98",
    "outputs": [],
    "execution_count": null
@@ -458,21 +446,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": [
-    "nv_75 = float(metrics.n_videos.quantile(0.75))\n",
-    "nvf_75 = float(metrics.n_videos_fil.quantile(0.75))\n",
-    "dw_75 = float(metrics.date_weight.quantile(0.75))\n",
-    "dwf_75 = float(metrics.date_weight_fil.quantile(0.75))\n",
-    "\n",
-    "not_following = metrics.loc[~metrics.channel_id.isin(channel_from_local.channel_id), :]\n",
-    "\n",
-    "to_follow = not_following.loc[(not_following['n_videos'] > nv_75) &\n",
-    "                              (not_following['n_videos_fil'] > nvf_75) &\n",
-    "                              (not_following['date_weight'] > dw_75) &\n",
-    "                              (not_following['date_weight_fil'] > dwf_75), :]\n",
-    "\n",
-    "print(to_follow[['channel_name', 'channel_id']])"
-   ],
+   "source": "nv_75 = float(metrics.n_videos.quantile(0.75))\nnvf_75 = float(metrics.n_videos_fil.quantile(0.75))\ndw_75 = float(metrics.date_weight.quantile(0.75))\ndwf_75 = float(metrics.date_weight_fil.quantile(0.75))\n\nnot_following = metrics.loc[~metrics.channel_id.isin(channel_from_local.channel_id), :]\n\nto_follow = not_following.loc[(not_following['n_videos'] > nv_75) &\n                              (not_following['n_videos_fil'] > nvf_75) &\n                              (not_following['date_weight'] > dw_75) &\n                              (not_following['date_weight_fil'] > dwf_75), :]\n\nto_follow[['channel_name', 'channel_id']]",
    "id": "e15d23ff903bfb15",
    "outputs": [],
    "execution_count": null
@@ -491,16 +465,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": [
-    "dw_25 = float(metrics.date_weight.quantile(0.25))\n",
-    "dwf_25 = float(metrics.date_weight_fil.quantile(0.25))\n",
-    "\n",
-    "listed = metrics.loc[metrics.channel_id.isin(channel_from_local.channel_id), :]\n",
-    "uninteresting = listed.loc[(listed['date_weight'] <= dw_25) &\n",
-    "                           (listed['date_weight_fil'] <= dwf_25), :]\n",
-    "\n",
-    "print(uninteresting[['channel_name', 'channel_id']])"
-   ],
+   "source": "dw_25 = float(metrics.date_weight.quantile(0.25))\ndwf_25 = float(metrics.date_weight_fil.quantile(0.25))\n\nlisted = metrics.loc[metrics.channel_id.isin(channel_from_local.channel_id), :]\nuninteresting = listed.loc[(listed['date_weight'] <= dw_25) &\n                           (listed['date_weight_fil'] <= dwf_25), :]\n\nuninteresting[['channel_name', 'channel_id']]",
    "id": "d9b60040820731a9",
    "outputs": [],
    "execution_count": null
@@ -518,10 +483,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": [
-    "unlisted = channel_from_local.loc[~channel_from_local.channel_id.isin(metrics.channel_id),:]\n",
-    "print(unlisted)"
-   ],
+   "source": "unlisted = channel_from_local.loc[~channel_from_local.channel_id.isin(metrics.channel_id), :]\nunlisted",
    "id": "f298b78c165e664e",
    "outputs": [],
    "execution_count": null

--- a/_scripts/archive_data.py
+++ b/_scripts/archive_data.py
@@ -11,21 +11,17 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 
-# Disable logging BEFORE importing yrt modules
-os.environ['YRT_NO_LOGGING'] = '1'
-
 # Third-party
 import pandas as pd
 
 # noinspection PyPackageRequirements
 from dateutil.relativedelta import relativedelta
 
+# Disable logging BEFORE importing yrt modules
+os.environ['YRT_NO_LOGGING'] = '1'
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
-
-# Local
-from yrt import paths
-from yrt.youtube import create_service_local, sort_db
 
 # Constants
 MONTHS_TO_ARCHIVE = 6
@@ -106,6 +102,8 @@ def archive_stats(cutoff: datetime) -> tuple[int, int]:
     Returns:
         Tuple of (archived_count, skipped_duplicates_count).
     """
+    from yrt import paths
+
     stats_path = paths.STATS_CSV
 
     if not stats_path.exists():
@@ -209,6 +207,8 @@ def archive_logs() -> int:
     Returns:
         Number of lines archived.
     """
+    from yrt import paths
+
     log_path = paths.HISTORY_LOG
     current_year = datetime.now(UTC).year
 
@@ -276,6 +276,8 @@ def archive_logs() -> int:
 
 def main() -> None:
     """Main function to run the archiving process."""
+    from yrt.youtube import create_service_local, sort_db
+
     cutoff = get_cutoff_date()
 
     print('=' * 60)

--- a/_scripts/archive_data.py
+++ b/_scripts/archive_data.py
@@ -8,22 +8,24 @@ Also sorts the PocketTube database alphabetically.
 import os
 import sys
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Disable logging BEFORE importing yrt modules
 os.environ['YRT_NO_LOGGING'] = '1'
 
 # Third-party
-import pandas as pd  # noqa: E402
-from dateutil.relativedelta import relativedelta  # noqa: E402
+import pandas as pd
+
+# noinspection PyPackageRequirements
+from dateutil.relativedelta import relativedelta
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Local (imported after setting YRT_NO_LOGGING)
-from yrt import paths  # noqa: E402
-from yrt.youtube import create_service_local, sort_db  # noqa: E402
+# Local
+from yrt import paths
+from yrt.youtube import create_service_local, sort_db
 
 # Constants
 MONTHS_TO_ARCHIVE = 6
@@ -32,9 +34,18 @@ LOG_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S%z'
 # Numeric columns that should be saved as integers (not floats)
 NUMERIC_COLUMNS = [
     'duration',
-    'views_w1', 'views_w4', 'views_w12', 'views_w24',
-    'likes_w1', 'likes_w4', 'likes_w12', 'likes_w24',
-    'comments_w1', 'comments_w4', 'comments_w12', 'comments_w24',
+    'views_w1',
+    'views_w4',
+    'views_w12',
+    'views_w24',
+    'likes_w1',
+    'likes_w4',
+    'likes_w12',
+    'likes_w24',
+    'comments_w1',
+    'comments_w4',
+    'comments_w12',
+    'comments_w24',
 ]
 
 
@@ -44,7 +55,7 @@ def get_cutoff_date() -> datetime:
     Returns:
         Timezone-aware datetime 6 months ago from today.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return now - relativedelta(months=MONTHS_TO_ARCHIVE)
 
 
@@ -98,13 +109,13 @@ def archive_stats(cutoff: datetime) -> tuple[int, int]:
     stats_path = paths.STATS_CSV
 
     if not stats_path.exists():
-        print(f"  Stats file not found: {stats_path}")
+        print(f'  Stats file not found: {stats_path}')
         return 0, 0
 
     # Load stats
     df = pd.read_csv(stats_path)
     if df.empty:
-        print("  Stats file is empty.")
+        print('  Stats file is empty.')
         return 0, 0
 
     # Parse release_date to datetime
@@ -115,7 +126,7 @@ def archive_stats(cutoff: datetime) -> tuple[int, int]:
     to_keep = df[df['release_date_parsed'] >= cutoff].copy()
 
     if to_archive.empty:
-        print("  No stats entries older than 6 months to archive.")
+        print('  No stats entries older than 6 months to archive.')
         return 0, 0
 
     # Group by year
@@ -138,7 +149,7 @@ def archive_stats(cutoff: datetime) -> tuple[int, int]:
         skipped_count += year_skipped
 
         if year_df_clean.empty:
-            print(f"    {year}: All {len(year_df)} entries already in archive (skipped)")
+            print(f'    {year}: All {len(year_df)} entries already in archive (skipped)')
             continue
 
         # Drop helper columns before saving
@@ -160,8 +171,10 @@ def archive_stats(cutoff: datetime) -> tuple[int, int]:
             year_df_clean.to_csv(archive_file, mode='w', header=True, index=False)
 
         archived_count += len(year_df_clean)
-        print(f"    {year}: Archived {len(year_df_clean)} entries" +
-              (f" (skipped {year_skipped} duplicates)" if year_skipped > 0 else ""))
+        print(
+            f'    {year}: Archived {len(year_df_clean)} entries'
+            + (f' (skipped {year_skipped} duplicates)' if year_skipped > 0 else '')
+        )
 
     # Overwrite source with remaining entries
     to_keep = to_keep.drop(columns=['release_date_parsed'])
@@ -197,18 +210,18 @@ def archive_logs() -> int:
         Number of lines archived.
     """
     log_path = paths.HISTORY_LOG
-    current_year = datetime.now(timezone.utc).year
+    current_year = datetime.now(UTC).year
 
     if not log_path.exists():
-        print(f"  Log file not found: {log_path}")
+        print(f'  Log file not found: {log_path}')
         return 0
 
     # Read all lines (handle encoding errors gracefully)
-    with open(log_path, 'r', encoding='utf-8', errors='replace') as f:
+    with open(log_path, encoding='utf-8', errors='replace') as f:
         lines = f.readlines()
 
     if not lines:
-        print("  Log file is empty.")
+        print('  Log file is empty.')
         return 0
 
     # Split into archive (previous years) and keep (current year)
@@ -232,10 +245,10 @@ def archive_logs() -> int:
             to_keep.append(line)
 
     if malformed_count > 0:
-        print(f"  Warning: {malformed_count} malformed lines kept in source file")
+        print(f'  Warning: {malformed_count} malformed lines kept in source file')
 
     if not to_archive:
-        print("  No log entries from previous years to archive.")
+        print('  No log entries from previous years to archive.')
         return 0
 
     archived_count = 0
@@ -252,7 +265,7 @@ def archive_logs() -> int:
             f.writelines(year_lines)
 
         archived_count += len(year_lines)
-        print(f"    {year}: Archived {len(year_lines)} log lines")
+        print(f'    {year}: Archived {len(year_lines)} log lines')
 
     # Overwrite source with remaining lines
     with open(log_path, 'w', encoding='utf-8') as f:
@@ -265,47 +278,47 @@ def main() -> None:
     """Main function to run the archiving process."""
     cutoff = get_cutoff_date()
 
-    print("=" * 60)
-    print("YouTube Release Tracker - Data Archive Utility")
-    print("=" * 60)
-    current_year = datetime.now(timezone.utc).year
-    print(f"Current date: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}")
-    print(f"Stats cutoff: {cutoff.strftime('%Y-%m-%d')} (entries older than {MONTHS_TO_ARCHIVE} months)")
-    print(f"Logs cutoff:  Year < {current_year} (previous years)\n")
+    print('=' * 60)
+    print('YouTube Release Tracker - Data Archive Utility')
+    print('=' * 60)
+    current_year = datetime.now(UTC).year
+    print(f'Current date: {datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")}')
+    print(f'Stats cutoff: {cutoff.strftime("%Y-%m-%d")} (entries older than {MONTHS_TO_ARCHIVE} months)')
+    print(f'Logs cutoff:  Year < {current_year} (previous years)\n')
 
     # Archive stats
-    print("Archiving stats.csv...")
+    print('Archiving stats.csv...')
     stats_archived, stats_skipped = archive_stats(cutoff)
     print()
 
     # Archive logs
-    print("Archiving history.log...")
+    print('Archiving history.log...')
     logs_archived = archive_logs()
     print()
 
     # Sort PocketTube database
-    print("Sorting PocketTube database...")
+    print('Sorting PocketTube database...')
     try:
         service = create_service_local(log=False)
         sort_db(service=service, log=False)
         db_sorted = True
 
     except Exception as e:
-        print(f"  Failed to sort database: {e}")
+        print(f'  Failed to sort database: {e}')
         db_sorted = False
     print()
 
     # Summary
-    print("=" * 60)
-    print("Summary:")
-    print(f"  Stats entries archived: {stats_archived}")
+    print('=' * 60)
+    print('Summary:')
+    print(f'  Stats entries archived: {stats_archived}')
 
     if stats_skipped > 0:
-        print(f"  Stats duplicates skipped: {stats_skipped}")
+        print(f'  Stats duplicates skipped: {stats_skipped}')
 
-    print(f"  Log lines archived: {logs_archived}")
-    print(f"  Database sorted: {'Yes' if db_sorted else 'No'}")
-    print("=" * 60)
+    print(f'  Log lines archived: {logs_archived}')
+    print(f'  Database sorted: {"Yes" if db_sorted else "No"}')
+    print('=' * 60)
 
 
 if __name__ == '__main__':

--- a/_scripts/sort_db.py
+++ b/_scripts/sort_db.py
@@ -15,14 +15,14 @@ os.environ['YRT_NO_LOGGING'] = '1'
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Local (imported after setting YRT_NO_LOGGING)
-from yrt.youtube import create_service_local, sort_db  # noqa: E402
+# Local
+from yrt.youtube import create_service_local, sort_db
 
 
 def main() -> None:
     """Run database sorting."""
-    print("PocketTube Database Sorter")
-    print("=" * 40)
+    print('PocketTube Database Sorter')
+    print('=' * 40)
 
     service = create_service_local(log=False)
     sort_db(service=service, log=False)

--- a/_scripts/sort_db.py
+++ b/_scripts/sort_db.py
@@ -15,12 +15,11 @@ os.environ['YRT_NO_LOGGING'] = '1'
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Local
-from yrt.youtube import create_service_local, sort_db
-
 
 def main() -> None:
     """Run database sorting."""
+    from yrt.youtube import create_service_local, sort_db
+
     print('PocketTube Database Sorter')
     print('=' * 40)
 

--- a/_tests/conftest.py
+++ b/_tests/conftest.py
@@ -165,6 +165,4 @@ def allow_temp_files(tmp_path, monkeypatch):
     # Patch the ALLOWED_DIRS
     monkeypatch.setattr(file_utils, 'ALLOWED_DIRS', extended_allowed)
 
-    return
-
     # Cleanup happens automatically via monkeypatch

--- a/_tests/conftest.py
+++ b/_tests/conftest.py
@@ -5,7 +5,7 @@ import datetime as dt
 import json
 import os
 from pathlib import Path
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 # Third-party
 import pytest
@@ -52,7 +52,7 @@ def sample_video_data():
         'channel_title': 'Test Channel',
         'published_at': '2024-01-15T12:00:00Z',
         'duration': 'PT3M30S',  # 3 minutes 30 seconds
-        'is_shorts': False
+        'is_shorts': False,
     }
 
 
@@ -60,15 +60,12 @@ def sample_video_data():
 def sample_playlist_item():
     """Sample playlist item from YouTube API."""
     return {
-        'contentDetails': {
-            'videoId': 'dQw4w9WgXcQ',
-            'videoPublishedAt': '2024-01-15T12:00:00Z'
-        },
+        'contentDetails': {'videoId': 'dQw4w9WgXcQ', 'videoPublishedAt': '2024-01-15T12:00:00Z'},
         'snippet': {
             'title': 'Test Video Title',
             'channelId': 'UCuAXFkgsw1L7xaCfnd5JJOw',
-            'channelTitle': 'Test Channel'
-        }
+            'channelTitle': 'Test Channel',
+        },
     }
 
 
@@ -77,14 +74,8 @@ def sample_video_stats():
     """Sample video statistics from YouTube API."""
     return {
         'id': 'dQw4w9WgXcQ',
-        'statistics': {
-            'viewCount': '1000000',
-            'likeCount': '50000',
-            'commentCount': '1000'
-        },
-        'contentDetails': {
-            'duration': 'PT3M30S'
-        }
+        'statistics': {'viewCount': '1000000', 'likeCount': '50000', 'commentCount': '1000'},
+        'contentDetails': {'duration': 'PT3M30S'},
     }
 
 
@@ -113,28 +104,20 @@ def sample_pocket_tube_data():
         'MUSIQUE': ['UCchannel1', 'UCchannel2'],
         'APPRENTISSAGE': ['UCchannel3'],
         'DIVERTISSEMENT': ['UCchannel4'],
-        'GAMING': ['UCchannel5']
+        'GAMING': ['UCchannel5'],
     }
 
 
 @pytest.fixture
 def sample_playlists_data():
     """Sample playlists.json configuration."""
-    return {
-        'banger_radar': 'PLbanger123',
-        'release_radar': 'PLrelease456',
-        'watch_later': 'PLwatch789'
-    }
+    return {'banger_radar': 'PLbanger123', 'release_radar': 'PLrelease456', 'watch_later': 'PLwatch789'}
 
 
 @pytest.fixture
 def sample_addon_data():
     """Sample add-on.json configuration."""
-    return {
-        'favorites': ['UCchannel1'],
-        'playlistNotFoundPass': ['UCchannel6'],
-        'toPass': ['UCchannel7']
-    }
+    return {'favorites': ['UCchannel1'], 'playlistNotFoundPass': ['UCchannel6'], 'toPass': ['UCchannel7']}
 
 
 @pytest.fixture
@@ -177,11 +160,11 @@ def allow_temp_files(tmp_path, monkeypatch):
     # Get current allowed dirs and add temp path
     original_allowed = file_utils.ALLOWED_DIRS.copy()
     temp_dir = str(tmp_path.parent.parent)  # Get pytest's temp root
-    extended_allowed = original_allowed + [temp_dir]
+    extended_allowed = [*original_allowed, temp_dir]
 
     # Patch the ALLOWED_DIRS
     monkeypatch.setattr(file_utils, 'ALLOWED_DIRS', extended_allowed)
 
-    yield
+    return
 
     # Cleanup happens automatically via monkeypatch

--- a/_tests/test_config.py
+++ b/_tests/test_config.py
@@ -62,22 +62,21 @@ class TestLoadConfig:
     def test_load_constants_with_valid_file(tmp_path, monkeypatch):
         """Test loading a valid config file."""
         # Create a test config file
-        config_data = {
-            'api': {'batch_size': 100},
-            'network': {'timeout_seconds': 10}
-        }
+        config_data = {'api': {'batch_size': 100}, 'network': {'timeout_seconds': 10}}
         config_file = tmp_path / 'constants.json'
         with open(config_file, 'w') as f:
             json.dump(config_data, f)
 
         # Patch paths.CONSTANTS_JSON and file_utils.ALLOWED_DIRS
-        from yrt import paths, file_utils
+        from yrt import file_utils, paths
+
         monkeypatch.setattr(paths, 'CONSTANTS_JSON', config_file)
-        extended_allowed = file_utils.ALLOWED_DIRS + [str(tmp_path)]
+        extended_allowed = [*file_utils.ALLOWED_DIRS, str(tmp_path)]
         monkeypatch.setattr(file_utils, 'ALLOWED_DIRS', extended_allowed)
 
         # Import and test
-        from yrt.config import load_constants, DEFAULTS, _deep_merge
+        from yrt.config import DEFAULTS, _deep_merge, load_constants
+
         result = load_constants()
 
         # Verify merge happened correctly
@@ -90,16 +89,17 @@ class TestLoadConfig:
     @staticmethod
     def test_load_constants_with_missing_file_uses_defaults(tmp_path, monkeypatch):
         """Test that missing config file falls back to defaults."""
-        from yrt import paths, file_utils
+        from yrt import file_utils, paths
         from yrt.config import DEFAULTS
 
         # Point to non-existent file
         nonexistent_file = tmp_path / 'nonexistent.json'
         monkeypatch.setattr(paths, 'CONSTANTS_JSON', nonexistent_file)
-        extended_allowed = file_utils.ALLOWED_DIRS + [str(tmp_path)]
+        extended_allowed = [*file_utils.ALLOWED_DIRS, str(tmp_path)]
         monkeypatch.setattr(file_utils, 'ALLOWED_DIRS', extended_allowed)
 
         from yrt.config import load_constants
+
         result = load_constants()
 
         assert result == DEFAULTS
@@ -108,19 +108,19 @@ class TestLoadConfig:
     def test_load_constants_partial_override(tmp_path, monkeypatch):
         """Test partial config override preserves other defaults."""
         # Create config with only some values
-        config_data = {
-            'playlists': {'release_radar_target_size': 60}
-        }
+        config_data = {'playlists': {'release_radar_target_size': 60}}
         config_file = tmp_path / 'constants.json'
         with open(config_file, 'w') as f:
             json.dump(config_data, f)
 
-        from yrt import paths, file_utils
+        from yrt import file_utils, paths
+
         monkeypatch.setattr(paths, 'CONSTANTS_JSON', config_file)
-        extended_allowed = file_utils.ALLOWED_DIRS + [str(tmp_path)]
+        extended_allowed = [*file_utils.ALLOWED_DIRS, str(tmp_path)]
         monkeypatch.setattr(file_utils, 'ALLOWED_DIRS', extended_allowed)
 
-        from yrt.config import load_constants, DEFAULTS
+        from yrt.config import DEFAULTS, load_constants
+
         result = load_constants()
 
         # Overridden value
@@ -137,6 +137,7 @@ class TestConfigConstants:
     def test_api_batch_size_is_integer():
         """Test that API_BATCH_SIZE is an integer."""
         from yrt.config import API_BATCH_SIZE
+
         assert isinstance(API_BATCH_SIZE, int)
         assert API_BATCH_SIZE > 0
 
@@ -144,6 +145,7 @@ class TestConfigConstants:
     def test_max_retries_is_integer():
         """Test that MAX_RETRIES is an integer."""
         from yrt.config import MAX_RETRIES
+
         assert isinstance(MAX_RETRIES, int)
         assert MAX_RETRIES > 0
 
@@ -151,6 +153,7 @@ class TestConfigConstants:
     def test_base_delay_is_integer():
         """Test that BASE_DELAY is an integer."""
         from yrt.config import BASE_DELAY
+
         assert isinstance(BASE_DELAY, int)
         assert BASE_DELAY > 0
 
@@ -158,6 +161,7 @@ class TestConfigConstants:
     def test_max_backoff_is_integer():
         """Test that MAX_BACKOFF is an integer."""
         from yrt.config import MAX_BACKOFF
+
         assert isinstance(MAX_BACKOFF, int)
         assert MAX_BACKOFF > 0
 
@@ -165,6 +169,7 @@ class TestConfigConstants:
     def test_network_timeout_is_integer():
         """Test that NETWORK_TIMEOUT is an integer."""
         from yrt.config import NETWORK_TIMEOUT
+
         assert isinstance(NETWORK_TIMEOUT, int)
         assert NETWORK_TIMEOUT > 0
 
@@ -172,6 +177,7 @@ class TestConfigConstants:
     def test_release_radar_target_is_integer():
         """Test that RELEASE_RADAR_TARGET is an integer."""
         from yrt.config import RELEASE_RADAR_TARGET
+
         assert isinstance(RELEASE_RADAR_TARGET, int)
         assert RELEASE_RADAR_TARGET > 0
 
@@ -179,6 +185,7 @@ class TestConfigConstants:
     def test_relistening_age_weeks_is_integer():
         """Test that RELISTENING_AGE_WEEKS is an integer."""
         from yrt.config import RELISTENING_AGE_WEEKS
+
         assert isinstance(RELISTENING_AGE_WEEKS, int)
         assert RELISTENING_AGE_WEEKS > 0
 
@@ -186,6 +193,7 @@ class TestConfigConstants:
     def test_long_video_threshold_is_integer():
         """Test that LONG_VIDEO_THRESHOLD_MINUTES is an integer."""
         from yrt.config import LONG_VIDEO_THRESHOLD_MINUTES
+
         assert isinstance(LONG_VIDEO_THRESHOLD_MINUTES, int)
         assert LONG_VIDEO_THRESHOLD_MINUTES > 0
 
@@ -193,6 +201,7 @@ class TestConfigConstants:
     def test_stats_week_deltas_is_list():
         """Test that STATS_WEEK_DELTAS is a list of integers."""
         from yrt.config import STATS_WEEK_DELTAS
+
         assert isinstance(STATS_WEEK_DELTAS, list)
         assert len(STATS_WEEK_DELTAS) > 0
         assert all(isinstance(x, int) for x in STATS_WEEK_DELTAS)
@@ -205,34 +214,40 @@ class TestDefaultValues:
     def test_default_batch_size():
         """Test default API batch size is 50."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['api']['batch_size'] == 50
 
     @staticmethod
     def test_default_max_retries():
         """Test default max retries is 3."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['api']['max_retries'] == 3
 
     @staticmethod
     def test_default_timeout():
         """Test default network timeout is 5 seconds."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['network']['timeout_seconds'] == 5
 
     @staticmethod
     def test_default_release_radar_target():
         """Test default Release Radar target is 40."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['playlists']['release_radar_target_size'] == 40
 
     @staticmethod
     def test_default_long_video_threshold():
         """Test default long video threshold is 10 minutes."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['video']['long_video_threshold_minutes'] == 10
 
     @staticmethod
     def test_default_week_deltas():
         """Test default week deltas are [1, 4, 12, 24]."""
         from yrt.config import DEFAULTS
+
         assert DEFAULTS['stats']['week_deltas'] == [1, 4, 12, 24]

--- a/_tests/test_constants.py
+++ b/_tests/test_constants.py
@@ -5,35 +5,35 @@ import pytest
 
 # Local
 from yrt.constants import (
-    # Routing
-    ROUTING_SHORTS,
-    ROUTING_NONE,
+    CATEGORY_ASMR,
+    CATEGORY_ENTERTAINMENT,
+    CATEGORY_GAMING,
+    CATEGORY_LEARNING,
+    # Category constants
+    CATEGORY_MUSIC,
+    CATEGORY_PRIORITY,
+    # Channel prefixes
+    CHANNEL_PREFIX,
+    # Date formats
+    ISO_DATE_FORMAT,
+    LIVE_STATUS_LIVE,
     # Live statuses
     LIVE_STATUS_NONE,
     LIVE_STATUS_UPCOMING,
-    LIVE_STATUS_LIVE,
+    LOG_DATE_FORMAT,
+    PERMANENT_ERRORS,
+    QUOTA_ERRORS,
+    ROUTING_NONE,
+    # Routing
+    ROUTING_SHORTS,
+    STATUS_DELETED,
+    STATUS_PRIVATE,
     # Video statuses
     STATUS_PUBLIC,
     STATUS_UNLISTED,
-    STATUS_PRIVATE,
-    STATUS_DELETED,
     # Error categories
     TRANSIENT_ERRORS,
-    PERMANENT_ERRORS,
-    QUOTA_ERRORS,
-    # Date formats
-    ISO_DATE_FORMAT,
-    LOG_DATE_FORMAT,
-    # Channel prefixes
-    CHANNEL_PREFIX,
     UPLOAD_PLAYLIST_PREFIX,
-    # Category constants
-    CATEGORY_MUSIC,
-    CATEGORY_LEARNING,
-    CATEGORY_ENTERTAINMENT,
-    CATEGORY_GAMING,
-    CATEGORY_ASMR,
-    CATEGORY_PRIORITY,
 )
 
 
@@ -252,7 +252,7 @@ class TestCategoryConstants:
             CATEGORY_GAMING,
             CATEGORY_ASMR,
         )
-        assert CATEGORY_PRIORITY == expected
+        assert expected == CATEGORY_PRIORITY
 
     @staticmethod
     def test_category_priority_excludes_musique():
@@ -267,27 +267,27 @@ class TestBackwardCompatibility:
     @staticmethod
     def test_utils_exports_transient_errors():
         """Test TRANSIENT_ERRORS importable from utils."""
-        # noinspection PyPep8Naming
-        from yrt.youtube.utils import TRANSIENT_ERRORS as utils_errors
-        assert utils_errors is TRANSIENT_ERRORS
+        from yrt.youtube.utils import TRANSIENT_ERRORS as UTILS_TRANSIENT_ERRORS
+
+        assert UTILS_TRANSIENT_ERRORS is TRANSIENT_ERRORS
 
     @staticmethod
     def test_utils_exports_permanent_errors():
         """Test PERMANENT_ERRORS importable from utils."""
-        # noinspection PyPep8Naming
-        from yrt.youtube.utils import PERMANENT_ERRORS as utils_errors
-        assert utils_errors is PERMANENT_ERRORS
+        from yrt.youtube.utils import PERMANENT_ERRORS as UTILS_PERMANENT_ERRORS
+
+        assert UTILS_PERMANENT_ERRORS is PERMANENT_ERRORS
 
     @staticmethod
     def test_utils_exports_quota_errors():
         """Test QUOTA_ERRORS importable from utils."""
-        # noinspection PyPep8Naming
-        from yrt.youtube.utils import QUOTA_ERRORS as utils_errors
-        assert utils_errors is QUOTA_ERRORS
+        from yrt.youtube.utils import QUOTA_ERRORS as UTILS_QUOTA_ERRORS
+
+        assert UTILS_QUOTA_ERRORS is QUOTA_ERRORS
 
     @staticmethod
     def test_utils_exports_iso_date_format():
         """Test ISO_DATE_FORMAT importable from utils."""
-        # noinspection PyPep8Naming
-        from yrt.youtube.utils import ISO_DATE_FORMAT as utils_format
-        assert utils_format is ISO_DATE_FORMAT
+        from yrt.youtube.utils import ISO_DATE_FORMAT as UTILS_ISO_DATE_FORMAT
+
+        assert UTILS_ISO_DATE_FORMAT is ISO_DATE_FORMAT

--- a/_tests/test_exceptions.py
+++ b/_tests/test_exceptions.py
@@ -5,12 +5,12 @@ import pytest
 
 # Local
 from yrt.exceptions import (
-    YouTubeTrackerError,
+    APIError,
     ConfigurationError,
+    CredentialsError,
     FileAccessError,
     YouTubeServiceError,
-    CredentialsError,
-    APIError
+    YouTubeTrackerError,
 )
 
 
@@ -21,54 +21,54 @@ class TestExceptionHierarchy:
     @staticmethod
     def test_base_exception():
         """Test YouTubeTrackerError base exception."""
-        error = YouTubeTrackerError("Base error message")
-        assert str(error) == "Base error message"
+        error = YouTubeTrackerError('Base error message')
+        assert str(error) == 'Base error message'
         assert isinstance(error, Exception)
 
     @staticmethod
     def test_configuration_error():
         """Test ConfigurationError inherits from base."""
-        error = ConfigurationError("Config error")
+        error = ConfigurationError('Config error')
         assert isinstance(error, YouTubeTrackerError)
-        assert str(error) == "Config error"
+        assert str(error) == 'Config error'
 
     @staticmethod
     def test_file_access_error():
         """Test FileAccessError inherits from base."""
-        error = FileAccessError("File access denied")
+        error = FileAccessError('File access denied')
         assert isinstance(error, YouTubeTrackerError)
-        assert str(error) == "File access denied"
+        assert str(error) == 'File access denied'
 
     @staticmethod
     def test_youtube_service_error():
         """Test YouTubeServiceError inherits from base."""
-        error = YouTubeServiceError("Service creation failed")
+        error = YouTubeServiceError('Service creation failed')
         assert isinstance(error, YouTubeTrackerError)
-        assert str(error) == "Service creation failed"
+        assert str(error) == 'Service creation failed'
 
     @staticmethod
     def test_credentials_error():
         """Test CredentialsError inherits from base."""
-        error = CredentialsError("Invalid credentials")
+        error = CredentialsError('Invalid credentials')
         assert isinstance(error, YouTubeTrackerError)
-        assert str(error) == "Invalid credentials"
+        assert str(error) == 'Invalid credentials'
 
     @staticmethod
     def test_api_error():
         """Test APIError inherits from base."""
-        error = APIError("API call failed")
+        error = APIError('API call failed')
         assert isinstance(error, YouTubeTrackerError)
-        assert str(error) == "API call failed"
+        assert str(error) == 'API call failed'
 
     @staticmethod
     def test_exception_catching():
         """Test that all custom exceptions can be caught by base class."""
         exceptions = [
-            ConfigurationError("test"),
-            FileAccessError("test"),
-            YouTubeServiceError("test"),
-            CredentialsError("test"),
-            APIError("test")
+            ConfigurationError('test'),
+            FileAccessError('test'),
+            YouTubeServiceError('test'),
+            CredentialsError('test'),
+            APIError('test'),
         ]
 
         for exc in exceptions:

--- a/_tests/test_file_utils.py
+++ b/_tests/test_file_utils.py
@@ -83,7 +83,7 @@ class TestSaveJson:
 
         # Verify file was created and contains correct data
         assert Path(file_path).exists()
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             loaded = json.load(f)
         assert loaded == data
 
@@ -95,7 +95,7 @@ class TestSaveJson:
 
         file_utils.save_json(file_path, data)
 
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             content = f.read()
 
         # Check for proper indentation
@@ -114,7 +114,7 @@ class TestSaveJson:
         new_data = {'new': 'data'}
         file_utils.save_json(file_path, new_data)
 
-        with open(file_path, 'r', encoding='utf-8') as f:
+        with open(file_path, encoding='utf-8') as f:
             loaded = json.load(f)
         assert loaded == new_data
         assert 'old' not in loaded
@@ -136,13 +136,7 @@ class TestValidateNestedKeys:
     @staticmethod
     def test_validate_nested_keys():
         """Test validation of nested keys using dot notation."""
-        data = {
-            'level1': {
-                'level2': {
-                    'key': 'value'
-                }
-            }
-        }
+        data = {'level1': {'level2': {'key': 'value'}}}
         required = ['level1.level2.key']
 
         # Should not raise any exception

--- a/_tests/test_logging_utils.py
+++ b/_tests/test_logging_utils.py
@@ -16,20 +16,20 @@ class TestCreateFileLogger:
     @staticmethod
     def test_creates_logger_with_correct_name(tmp_path: Path) -> None:
         """Test that logger is created with the specified name."""
-        log_file = tmp_path / "test.log"
-        logger = create_file_logger("test_logger", log_file)
+        log_file = tmp_path / 'test.log'
+        logger = create_file_logger('test_logger', log_file)
 
-        assert logger.name == "test_logger"
+        assert logger.name == 'test_logger'
 
     @staticmethod
     def test_creates_logger_with_file_handler(tmp_path: Path) -> None:
         """Test that logger has a file handler when YRT_NO_LOGGING is not set."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {}, clear=True):
             # Ensure YRT_NO_LOGGING is not set
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger = create_file_logger("test_logger", log_file)
+            logger = create_file_logger('test_logger', log_file)
 
         assert len(logger.handlers) == 1
         assert isinstance(logger.handlers[0], logging.FileHandler)
@@ -37,20 +37,20 @@ class TestCreateFileLogger:
     @staticmethod
     def test_no_handler_when_yrt_no_logging_set(tmp_path: Path) -> None:
         """Test that no file handler is added when YRT_NO_LOGGING is set."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {'YRT_NO_LOGGING': '1'}):
-            logger = create_file_logger("test_logger", log_file)
+            logger = create_file_logger('test_logger', log_file)
 
         assert len(logger.handlers) == 0
 
     @staticmethod
     def test_respect_no_logging_false_ignores_env_var(tmp_path: Path) -> None:
         """Test that respect_no_logging=False ignores YRT_NO_LOGGING env var."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {'YRT_NO_LOGGING': '1'}):
-            logger = create_file_logger("test_logger", log_file, respect_no_logging=False)
+            logger = create_file_logger('test_logger', log_file, respect_no_logging=False)
 
         assert len(logger.handlers) == 1
         assert isinstance(logger.handlers[0], logging.FileHandler)
@@ -58,34 +58,34 @@ class TestCreateFileLogger:
     @staticmethod
     def test_default_level_is_debug(tmp_path: Path) -> None:
         """Test that the default handler level is DEBUG."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger = create_file_logger("test_logger", log_file)
+            logger = create_file_logger('test_logger', log_file)
 
         assert logger.handlers[0].level == logging.DEBUG
 
     @staticmethod
     def test_custom_level(tmp_path: Path) -> None:
         """Test that custom level is applied to handler."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger = create_file_logger("test_logger", log_file, level=logging.WARNING)
+            logger = create_file_logger('test_logger', log_file, level=logging.WARNING)
 
         assert logger.handlers[0].level == logging.WARNING
 
     @staticmethod
     def test_logger_writes_to_file(tmp_path: Path) -> None:
         """Test that logger actually writes to the specified file."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger = create_file_logger("test_logger", log_file)
-            logger.info("Test message")
+            logger = create_file_logger('test_logger', log_file)
+            logger.info('Test message')
 
             # Flush handler to ensure write
             for handler in logger.handlers:
@@ -93,44 +93,44 @@ class TestCreateFileLogger:
 
         assert log_file.exists()
         content = log_file.read_text()
-        assert "Test message" in content
+        assert 'Test message' in content
 
     @staticmethod
     def test_formatter_format(tmp_path: Path) -> None:
         """Test that the log formatter produces expected format."""
-        log_file = tmp_path / "test.log"
+        log_file = tmp_path / 'test.log'
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger = create_file_logger("test_logger", log_file)
-            logger.warning("Test warning")
+            logger = create_file_logger('test_logger', log_file)
+            logger.warning('Test warning')
 
             for handler in logger.handlers:
                 handler.flush()
 
         content = log_file.read_text()
         # Check format includes expected components
-        assert "[WARNING]" in content
-        assert "Test warning" in content
+        assert '[WARNING]' in content
+        assert 'Test warning' in content
 
     @staticmethod
     def test_logger_base_level_is_zero(tmp_path: Path) -> None:
         """Test that the logger base level is 0 (logs everything)."""
-        log_file = tmp_path / "test.log"
-        logger = create_file_logger("test_logger", log_file)
+        log_file = tmp_path / 'test.log'
+        logger = create_file_logger('test_logger', log_file)
 
         assert logger.level == 0
 
     @staticmethod
     def test_multiple_loggers_independent(tmp_path: Path) -> None:
         """Test that multiple loggers with different names are independent."""
-        log_file1 = tmp_path / "test1.log"
-        log_file2 = tmp_path / "test2.log"
+        log_file1 = tmp_path / 'test1.log'
+        log_file2 = tmp_path / 'test2.log'
 
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop('YRT_NO_LOGGING', None)
-            logger1 = create_file_logger("logger1", log_file1)
-            logger2 = create_file_logger("logger2", log_file2)
+            logger1 = create_file_logger('logger1', log_file1)
+            logger2 = create_file_logger('logger2', log_file2)
 
         assert logger1.name != logger2.name
         assert logger1 is not logger2

--- a/_tests/test_main.py
+++ b/_tests/test_main.py
@@ -8,37 +8,37 @@ import pytest
 class TestDestPlaylist:
     """Test dest_playlist() video routing logic."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_shorts_are_ignored(self):
         """Test shorts return 'shorts' destination (not added to playlists)."""
         # This test documents expected behavior for shorts
         # Actual implementation will depend on dest_playlist() function signature
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_music_channel_short_video_to_release_radar(self):
         """Test music channel videos < 10 min go to Release Radar."""
         # Duration < 10 minutes, music channel, not in favorites
         # Expected: Release Radar
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_music_channel_long_video_music_only(self):
         """Test music channel videos > 10 min (music-only) return 'none'."""
         # Duration > 10 minutes, music-only channel
         # Expected: 'none' (not added)
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_music_channel_long_video_other_categories(self):
         """Test music channel videos > 10 min (also in other categories) go to Watch Later."""
         # Duration > 10 minutes, channel also in APPRENTISSAGE/DIVERTISSEMENT/GAMING
         # Expected: Watch Later
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_favorite_channel_to_banger_radar(self):
         """Test favorite channel videos go to Banger Radar."""
         # Music channel in favorites list
         # Expected: Banger Radar
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_non_music_channel_to_watch_later(self):
         """Test non-music channel videos go to Watch Later."""
         # Channel not in MUSIQUE category
@@ -49,16 +49,16 @@ class TestDestPlaylist:
 class TestConfigurationLoading:
     """Test configuration file loading in main module."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_loads_pocket_tube_config(self):
         """Test main module loads pocket_tube.json."""
         # Verify configuration loading happens
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_loads_playlists_config(self):
         """Test main module loads playlists.json."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_loads_addon_config(self):
         """Test main module loads add-on.json."""
 
@@ -67,14 +67,15 @@ class TestConfigurationLoading:
 class TestMainFunction:
     """Test main() orchestration function."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_main_function_exists(self):
         """Test main() function exists and is callable."""
         from yrt import main
+
         assert hasattr(main, 'main')
         # Main function should exist for proper entry point
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_main_handles_exceptions(self):
         """Test main() has top-level exception handler."""
         # Should catch YouTubeTrackerError subclasses
@@ -84,12 +85,12 @@ class TestMainFunction:
 class TestCopyLastExeLog:
     """Test copy_last_exe_log() function behavior."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_copy_last_exe_log_exists(self):
         """Test copy_last_exe_log() function exists."""
         # This function extracts most recent run logs
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_copy_last_exe_log_only_on_success(self):
         """Test copy_last_exe_log() only runs after successful execution."""
         # Should not update last_exe.log if execution failed
@@ -100,11 +101,11 @@ class TestCopyLastExeLog:
 class TestUpdateRepoSecrets:
     """Test update_repo_secrets() for GitHub Actions mode."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_update_repo_secrets_exists(self):
         """Test update_repo_secrets() function exists."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_update_repo_secrets_uses_github_api(self):
         """Test function uses GitHub API to update secrets."""
         # Should use PyGithub library
@@ -114,15 +115,15 @@ class TestUpdateRepoSecrets:
 class TestWorkflowMode:
     """Test GitHub Actions workflow mode ('action' argument)."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_detects_action_mode_from_argv(self):
         """Test script detects 'action' mode from sys.argv."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_action_mode_uses_base64_credentials(self):
         """Test action mode uses CREDS_B64 environment variable."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_action_mode_no_progress_bars(self):
         """Test action mode doesn't use tqdm progress bars."""
 
@@ -131,10 +132,10 @@ class TestWorkflowMode:
 class TestLocalMode:
     """Test local development mode."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_local_mode_uses_token_files(self):
         """Test local mode loads credentials from _tokens/ directory."""
 
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_local_mode_shows_progress_bars(self):
         """Test local mode uses tqdm for progress indication."""

--- a/_tests/test_models.py
+++ b/_tests/test_models.py
@@ -8,16 +8,15 @@ import pytest
 
 # Local
 from yrt.models import (
-    PlaylistConfig,
     AddOnConfig,
+    PlaylistConfig,
     PlaylistItem,
-    VideoStats,
-    VideoData,
     PlaylistItemRef,
+    VideoData,
+    VideoStats,
     to_dict,
-    to_dict_list
+    to_dict_list,
 )
-
 
 # === PlaylistConfig Tests ===
 
@@ -25,11 +24,7 @@ from yrt.models import (
 def test_playlist_config_creation():
     """Test PlaylistConfig creation with valid data."""
     config = PlaylistConfig(
-        id='PL123',
-        name='Test Playlist',
-        description='Test Description',
-        retention_days=7,
-        cleanup_on_end=True
+        id='PL123', name='Test Playlist', description='Test Description', retention_days=7, cleanup_on_end=True
     )
     assert config.id == 'PL123'
     assert config.name == 'Test Playlist'
@@ -40,44 +35,27 @@ def test_playlist_config_creation():
 
 def test_playlist_config_optional_fields():
     """Test PlaylistConfig with optional fields omitted."""
-    config = PlaylistConfig(
-        id='PL123',
-        name='Test Playlist',
-        description='Test Description'
-    )
+    config = PlaylistConfig(id='PL123', name='Test Playlist', description='Test Description')
     assert config.retention_days is None
     assert config.cleanup_on_end is None
 
 
 def test_playlist_config_validation_empty_id():
     """Test PlaylistConfig raises ValueError for empty ID."""
-    with pytest.raises(ValueError, match="Playlist ID cannot be empty"):
-        PlaylistConfig(
-            id='',
-            name='Test Playlist',
-            description='Test Description'
-        )
+    with pytest.raises(ValueError, match='Playlist ID cannot be empty'):
+        PlaylistConfig(id='', name='Test Playlist', description='Test Description')
 
 
 def test_playlist_config_validation_empty_name():
     """Test PlaylistConfig raises ValueError for empty name."""
-    with pytest.raises(ValueError, match="Playlist name cannot be empty"):
-        PlaylistConfig(
-            id='PL123',
-            name='',
-            description='Test Description'
-        )
+    with pytest.raises(ValueError, match='Playlist name cannot be empty'):
+        PlaylistConfig(id='PL123', name='', description='Test Description')
 
 
 def test_playlist_config_validation_negative_retention():
     """Test PlaylistConfig raises ValueError for negative retention_days."""
-    with pytest.raises(ValueError, match="retention_days must be >= 0"):
-        PlaylistConfig(
-            id='PL123',
-            name='Test Playlist',
-            description='Test Description',
-            retention_days=-1
-        )
+    with pytest.raises(ValueError, match='retention_days must be >= 0'):
+        PlaylistConfig(id='PL123', name='Test Playlist', description='Test Description', retention_days=-1)
 
 
 # === AddOnConfig Tests ===
@@ -89,7 +67,7 @@ def test_addon_config_creation():
         favorites={'Artist1': 'UC123', 'Artist2': 'UC456'},
         playlist_not_found_pass=['UC789'],
         to_pass=['UC999'],
-        certified=['UC111']
+        certified=['UC111'],
     )
     assert config.favorites == {'Artist1': 'UC123', 'Artist2': 'UC456'}
     assert config.playlist_not_found_pass == ['UC789']
@@ -108,7 +86,7 @@ def test_addon_config_defaults():
 
 def test_addon_config_validation_invalid_favorites():
     """Test AddOnConfig raises ValueError for non-dict favorites."""
-    with pytest.raises(ValueError, match="favorites must be a dict"):
+    with pytest.raises(ValueError, match='favorites must be a dict'):
         AddOnConfig(favorites=['not', 'a', 'dict'])  # type: ignore[arg-type]
 
 
@@ -126,7 +104,7 @@ def test_playlist_item_creation():
         status='public',
         channel_id='UC789',
         channel_name='Test Channel',
-        source_channel_id='UC999'
+        source_channel_id='UC999',
     )
     assert item.video_id == 'vid123'
     assert item.video_title == 'Test Video'
@@ -140,7 +118,7 @@ def test_playlist_item_creation():
 
 def test_playlist_item_validation_empty_video_id():
     """Test PlaylistItem raises ValueError for empty video_id."""
-    with pytest.raises(ValueError, match="video_id cannot be empty"):
+    with pytest.raises(ValueError, match='video_id cannot be empty'):
         PlaylistItem(
             video_id='',
             video_title='Test',
@@ -149,13 +127,13 @@ def test_playlist_item_validation_empty_video_id():
             status='public',
             channel_id='UC123',
             channel_name='Test',
-            source_channel_id='UC456'
+            source_channel_id='UC456',
         )
 
 
 def test_playlist_item_validation_empty_source_channel():
     """Test PlaylistItem raises ValueError for empty source_channel_id."""
-    with pytest.raises(ValueError, match="source_channel_id cannot be empty"):
+    with pytest.raises(ValueError, match='source_channel_id cannot be empty'):
         PlaylistItem(
             video_id='vid123',
             video_title='Test',
@@ -164,7 +142,7 @@ def test_playlist_item_validation_empty_source_channel():
             status='public',
             channel_id='UC123',
             channel_name='Test',
-            source_channel_id=''
+            source_channel_id='',
         )
 
 
@@ -181,7 +159,7 @@ def test_video_stats_creation():
         duration=300,
         is_shorts=False,
         live_status='none',
-        latest_status='public'
+        latest_status='public',
     )
     assert stats.video_id == 'vid123'
     assert stats.views == 1000
@@ -208,7 +186,7 @@ def test_video_stats_defaults():
 
 def test_video_stats_validation_empty_video_id():
     """Test VideoStats raises ValueError for empty video_id."""
-    with pytest.raises(ValueError, match="video_id cannot be empty"):
+    with pytest.raises(ValueError, match='video_id cannot be empty'):
         VideoStats(video_id='')
 
 
@@ -234,7 +212,7 @@ def test_video_data_creation():
         is_shorts=False,
         live_status='none',
         latest_status='public',
-        dest_playlist='PL123'
+        dest_playlist='PL123',
     )
     assert data.video_id == 'vid123'
     assert data.views == 1000
@@ -253,7 +231,7 @@ def test_video_data_factory_method():
         status='public',
         channel_id='UC789',
         channel_name='Test Channel',
-        source_channel_id='UC999'
+        source_channel_id='UC999',
     )
 
     stats = VideoStats(
@@ -264,7 +242,7 @@ def test_video_data_factory_method():
         duration=300,
         is_shorts=False,
         live_status='upcoming',
-        latest_status='public'
+        latest_status='public',
     )
 
     data = VideoData.from_playlist_item_and_stats(item, stats)
@@ -302,13 +280,10 @@ def test_video_data_factory_none_live_status():
         status='public',
         channel_id='UC789',
         channel_name='Test',
-        source_channel_id='UC999'
+        source_channel_id='UC999',
     )
 
-    stats = VideoStats(
-        video_id='vid123',
-        live_status=None
-    )
+    stats = VideoStats(video_id='vid123', live_status=None)
 
     data = VideoData.from_playlist_item_and_stats(item, stats)
     assert data.live_status == 'none'
@@ -320,11 +295,7 @@ def test_video_data_factory_none_live_status():
 def test_playlist_item_ref_creation():
     """Test PlaylistItemRef creation with all fields."""
     add_date = datetime(2024, 1, 15, 12, 0, 0)
-    ref = PlaylistItemRef(
-        item_id='item123',
-        video_id='vid456',
-        add_date=add_date
-    )
+    ref = PlaylistItemRef(item_id='item123', video_id='vid456', add_date=add_date)
     assert ref.item_id == 'item123'
     assert ref.video_id == 'vid456'
     assert ref.add_date == add_date
@@ -332,10 +303,7 @@ def test_playlist_item_ref_creation():
 
 def test_playlist_item_ref_without_add_date():
     """Test PlaylistItemRef creation without optional add_date."""
-    ref = PlaylistItemRef(
-        item_id='item123',
-        video_id='vid456'
-    )
+    ref = PlaylistItemRef(item_id='item123', video_id='vid456')
     assert ref.item_id == 'item123'
     assert ref.video_id == 'vid456'
     assert ref.add_date is None
@@ -343,13 +311,13 @@ def test_playlist_item_ref_without_add_date():
 
 def test_playlist_item_ref_validation_empty_item_id():
     """Test PlaylistItemRef raises ValueError for empty item_id."""
-    with pytest.raises(ValueError, match="item_id cannot be empty"):
+    with pytest.raises(ValueError, match='item_id cannot be empty'):
         PlaylistItemRef(item_id='', video_id='vid123')
 
 
 def test_playlist_item_ref_validation_empty_video_id():
     """Test PlaylistItemRef raises ValueError for empty video_id."""
-    with pytest.raises(ValueError, match="video_id cannot be empty"):
+    with pytest.raises(ValueError, match='video_id cannot be empty'):
         PlaylistItemRef(item_id='item123', video_id='')
 
 
@@ -358,12 +326,7 @@ def test_playlist_item_ref_validation_empty_video_id():
 
 def test_to_dict_with_playlist_config():
     """Test to_dict() converts PlaylistConfig to dict."""
-    config = PlaylistConfig(
-        id='PL123',
-        name='Test Playlist',
-        description='Test Description',
-        retention_days=7
-    )
+    config = PlaylistConfig(id='PL123', name='Test Playlist', description='Test Description', retention_days=7)
     result = to_dict(config)
 
     assert isinstance(result, dict)
@@ -385,7 +348,7 @@ def test_to_dict_with_datetime():
         status='public',
         channel_id='UC789',
         channel_name='Test',
-        source_channel_id='UC999'
+        source_channel_id='UC999',
     )
     result = to_dict(item)
 
@@ -396,7 +359,7 @@ def test_to_dict_with_datetime():
 
 def test_to_dict_non_dataclass_raises_error():
     """Test to_dict() raises TypeError for non-dataclass input."""
-    with pytest.raises(TypeError, match="Expected dataclass"):
+    with pytest.raises(TypeError, match='Expected dataclass'):
         to_dict({'not': 'a dataclass'})  # type: ignore[arg-type]
 
 
@@ -405,7 +368,7 @@ def test_to_dict_list():
     items = [
         PlaylistItemRef(item_id='item1', video_id='vid1'),
         PlaylistItemRef(item_id='item2', video_id='vid2'),
-        PlaylistItemRef(item_id='item3', video_id='vid3')
+        PlaylistItemRef(item_id='item3', video_id='vid3'),
     ]
 
     result = to_dict_list(items)

--- a/_tests/test_router.py
+++ b/_tests/test_router.py
@@ -3,10 +3,10 @@
 # Third-party
 import pytest
 
+from yrt.models import AddOnConfig, PlaylistConfig
+
 # Local
 from yrt.router import RouterConfig, VideoRouter, create_router_from_config
-from yrt.models import PlaylistConfig, AddOnConfig
-
 
 # === Fixtures ===
 
@@ -34,7 +34,7 @@ def sample_router_config():
         banger_radar_id='PL_banger',
         music_lives_id='PL_music_lives',
         regular_streams_id='PL_regular_streams',
-        long_video_threshold_minutes=10
+        long_video_threshold_minutes=10,
     )
 
 
@@ -60,7 +60,7 @@ class TestRouterConfig:
     @staticmethod
     def test_validation_empty_release_radar():
         """Test validation rejects empty release_radar_id."""
-        with pytest.raises(ValueError, match="release_radar_id cannot be empty"):
+        with pytest.raises(ValueError, match='release_radar_id cannot be empty'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -70,13 +70,13 @@ class TestRouterConfig:
                 release_radar_id='',
                 banger_radar_id='PL_banger',
                 music_lives_id='PL_lives',
-                regular_streams_id='PL_streams'
+                regular_streams_id='PL_streams',
             )
 
     @staticmethod
     def test_validation_empty_banger_radar():
         """Test validation rejects empty banger_radar_id."""
-        with pytest.raises(ValueError, match="banger_radar_id cannot be empty"):
+        with pytest.raises(ValueError, match='banger_radar_id cannot be empty'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -86,13 +86,13 @@ class TestRouterConfig:
                 release_radar_id='PL_release',
                 banger_radar_id='',
                 music_lives_id='PL_lives',
-                regular_streams_id='PL_streams'
+                regular_streams_id='PL_streams',
             )
 
     @staticmethod
     def test_validation_empty_music_lives():
         """Test validation rejects empty music_lives_id."""
-        with pytest.raises(ValueError, match="music_lives_id cannot be empty"):
+        with pytest.raises(ValueError, match='music_lives_id cannot be empty'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -102,13 +102,13 @@ class TestRouterConfig:
                 release_radar_id='PL_release',
                 banger_radar_id='PL_banger',
                 music_lives_id='',
-                regular_streams_id='PL_streams'
+                regular_streams_id='PL_streams',
             )
 
     @staticmethod
     def test_validation_empty_regular_streams():
         """Test validation rejects empty regular_streams_id."""
-        with pytest.raises(ValueError, match="regular_streams_id cannot be empty"):
+        with pytest.raises(ValueError, match='regular_streams_id cannot be empty'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -118,13 +118,13 @@ class TestRouterConfig:
                 release_radar_id='PL_release',
                 banger_radar_id='PL_banger',
                 music_lives_id='PL_lives',
-                regular_streams_id=''
+                regular_streams_id='',
             )
 
     @staticmethod
     def test_validation_zero_threshold():
         """Test validation rejects zero threshold."""
-        with pytest.raises(ValueError, match="long_video_threshold_minutes must be positive"):
+        with pytest.raises(ValueError, match='long_video_threshold_minutes must be positive'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -135,13 +135,13 @@ class TestRouterConfig:
                 banger_radar_id='PL_banger',
                 music_lives_id='PL_lives',
                 regular_streams_id='PL_streams',
-                long_video_threshold_minutes=0
+                long_video_threshold_minutes=0,
             )
 
     @staticmethod
     def test_validation_negative_threshold():
         """Test validation rejects negative threshold."""
-        with pytest.raises(ValueError, match="long_video_threshold_minutes must be positive"):
+        with pytest.raises(ValueError, match='long_video_threshold_minutes must be positive'):
             RouterConfig(
                 music_channels=set(),
                 favorite_channels=set(),
@@ -152,7 +152,7 @@ class TestRouterConfig:
                 banger_radar_id='PL_banger',
                 music_lives_id='PL_lives',
                 regular_streams_id='PL_streams',
-                long_video_threshold_minutes=-5
+                long_video_threshold_minutes=-5,
             )
 
 
@@ -198,38 +198,33 @@ class TestVideoRouterStreams:
     @staticmethod
     def test_upcoming_music_stream_to_music_lives(router):
         """Test upcoming streams from music channels go to music_lives."""
-        result = router.route('UC_music_1', is_shorts=False, duration=None,
-                              live_status='upcoming')
+        result = router.route('UC_music_1', is_shorts=False, duration=None, live_status='upcoming')
         assert result == 'PL_music_lives'
 
     @staticmethod
     def test_upcoming_nonmusic_stream_to_regular(router):
         """Test upcoming streams from non-music channels go to regular_streams."""
-        result = router.route('UC_learn_1', is_shorts=False, duration=None,
-                              live_status='upcoming')
+        result = router.route('UC_learn_1', is_shorts=False, duration=None, live_status='upcoming')
         assert result == 'PL_regular_streams'
 
     @staticmethod
     def test_stream_routing_takes_precedence_over_shorts(router):
         """Test stream routing happens before shorts check."""
         # Even if is_shorts=True, upcoming stream should go to stream playlist
-        result = router.route('UC_music_1', is_shorts=True, duration=None,
-                              live_status='upcoming')
+        result = router.route('UC_music_1', is_shorts=True, duration=None, live_status='upcoming')
         assert result == 'PL_music_lives'
 
     @staticmethod
     def test_live_status_none_bypasses_stream_routing(router):
         """Test live_status='none' does not trigger stream routing."""
-        result = router.route('UC_music_2', is_shorts=False, duration=120,
-                              live_status='none')
+        result = router.route('UC_music_2', is_shorts=False, duration=120, live_status='none')
         assert result == 'PL_release'
 
     @staticmethod
     def test_live_status_live_bypasses_stream_routing(router):
         """Test live_status='live' does not trigger stream routing."""
         # Currently active streams are treated as regular videos
-        result = router.route('UC_music_2', is_shorts=False, duration=120,
-                              live_status='live')
+        result = router.route('UC_music_2', is_shorts=False, duration=120, live_status='live')
         assert result == 'PL_release'
 
 
@@ -416,6 +411,7 @@ class TestCreateRouterFromConfig:
     def test_uses_default_threshold(monkeypatch):
         """Test factory uses config.LONG_VIDEO_THRESHOLD_MINUTES by default."""
         from yrt import config
+
         monkeypatch.setattr(config, 'LONG_VIDEO_THRESHOLD_MINUTES', 15)
 
         pocket_tube = {'MUSIQUE': [], 'APPRENTISSAGE': [], 'DIVERTISSEMENT': [], 'GAMING': []}
@@ -449,9 +445,7 @@ class TestCreateRouterFromConfig:
         }
         add_on = AddOnConfig(favorites={})
 
-        router = create_router_from_config(
-            pocket_tube, playlists, add_on, long_video_threshold=20
-        )
+        router = create_router_from_config(pocket_tube, playlists, add_on, long_video_threshold=20)
 
         assert router.config.long_video_threshold_minutes == 20
 

--- a/_tests/test_youtube.py
+++ b/_tests/test_youtube.py
@@ -6,20 +6,20 @@ from unittest.mock import Mock, patch
 # Third-party
 import pytest
 
-# Local - explicit imports from submodules
-from yrt.youtube.utils import (
-    is_shorts,
-    ISO_DATE_FORMAT,
-    TRANSIENT_ERRORS,
-    PERMANENT_ERRORS,
-    QUOTA_ERRORS,
-)
+# Local
 from yrt.youtube.auth import (
-    encode_key,
     create_service_local,
     create_service_workflow,
+    encode_key,
 )
 from yrt.youtube.stats import get_stats
+from yrt.youtube.utils import (
+    ISO_DATE_FORMAT,
+    PERMANENT_ERRORS,
+    QUOTA_ERRORS,
+    TRANSIENT_ERRORS,
+    is_shorts,
+)
 
 
 @pytest.mark.unit
@@ -69,7 +69,7 @@ class TestIsShorts:
     @patch('yrt.youtube.utils.requests.head')
     def test_is_shorts_handles_network_error(self, mock_head, sample_video_id):
         """Test is_shorts() returns False on network errors."""
-        mock_head.side_effect = Exception("Network error")
+        mock_head.side_effect = Exception('Network error')
 
         result = is_shorts(sample_video_id)
 
@@ -107,6 +107,7 @@ class TestErrorConstants:
     def test_retry_constants_defined():
         """Test retry configuration constants are defined in config module."""
         from yrt import config
+
         assert hasattr(config, 'MAX_RETRIES')
         assert hasattr(config, 'BASE_DELAY')
         assert hasattr(config, 'MAX_BACKOFF')
@@ -120,7 +121,7 @@ class TestDurationParsing:
     """Test ISO 8601 duration parsing."""
 
     @staticmethod
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_parse_short_duration():
         """Test parsing short video duration (< 1 minute)."""
         # PT30S = 30 seconds
@@ -128,13 +129,13 @@ class TestDurationParsing:
         # If no helper exists, this documents expected behavior
 
     @staticmethod
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_parse_medium_duration():
         """Test parsing medium video duration (minutes)."""
         # PT3M30S = 3 minutes 30 seconds
 
     @staticmethod
-    @pytest.mark.skip("Not yet implemented")
+    @pytest.mark.skip('Not yet implemented')
     def test_parse_long_duration():
         """Test parsing long video duration (hours)."""
         # PT1H30M = 1 hour 30 minutes
@@ -149,6 +150,7 @@ class TestGetStats:
     def test_get_stats_has_check_shorts_parameter():
         """Test get_stats() accepts check_shorts parameter."""
         import inspect
+
         sig = inspect.signature(get_stats)
         assert 'check_shorts' in sig.parameters
 
@@ -156,6 +158,7 @@ class TestGetStats:
     def test_get_stats_check_shorts_default_true():
         """Test check_shorts defaults to True for new videos."""
         import inspect
+
         sig = inspect.signature(get_stats)
         param = sig.parameters['check_shorts']
         assert param.default is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "isodate>=0.7.2,<1",
     "pandas>=3.0.3,<4",
     "pygithub>=2.9.1,<3",
+    "python-dateutil>=2.9.0,<3",
     "python-youtube>=0.9.9,<1",
     "requests>=2.34.2,<3",
     "tqdm>=4.68.3,<5",
@@ -65,7 +66,48 @@ Issues = "https://github.com/Dyl-M/youtube_release_tracker/issues"
 # yrt = "yrt.main:cli"
 
 [tool.ruff]
+target-version = "py312"
+line-length = 120
 extend-exclude = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = [
+    "F", # pyflakes
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "I", # isort
+    "UP", # pyupgrade
+    "B", # flake8-bugbear
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific rules
+    "D", # pydocstyle
+    "N", # pep8-naming
+    "ANN", # flake8-annotations
+    "S", # flake8-bandit (security)
+    "T20", # flake8-print
+    "PT", # flake8-pytest-style
+    "RET", # flake8-return
+    "TCH", # flake8-type-checking
+]
+ignore = [
+    "D104", # missing docstring in public package (re-export __init__ files)
+    "ANN401", # explicit Any is intentional (codebase uses dict[str, Any] for API payloads)
+    "RUF022", # __all__ uses intentional comment-grouped ordering, not alphabetical
+]
+
+[tool.ruff.lint.per-file-ignores]
+"_tests/**" = ["ANN", "S101"] # tests: no annotations required, assert is expected
+"_scripts/**" = ["T20"] # maintenance scripts print progress to the console
+"yrt/main.py" = ["T20"] # local mode prints progress to the console
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.isort]
+known-first-party = ["yrt"]
+
+[tool.ruff.format]
+quote-style = "single" # preserve the codebase's single-quote convention
 
 [tool.mypy]
 python_version = "3.12"
@@ -74,6 +116,13 @@ warn_unused_configs = true
 warn_no_return = true
 warn_unreachable = true
 strict_optional = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = ["isodate.*", "pyyoutube.*", "tqdm.*", "google_auth_oauthlib.*", "tzlocal.*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,11 +88,14 @@ select = [
     "PT", # flake8-pytest-style
     "RET", # flake8-return
     "TCH", # flake8-type-checking
+    "PLR", # pylint refactor (catches useless-return and similar)
 ]
 ignore = [
     "D104", # missing docstring in public package (re-export __init__ files)
     "ANN401", # explicit Any is intentional (codebase uses dict[str, Any] for API payloads)
     "RUF022", # __all__ uses intentional comment-grouped ordering, not alphabetical
+    "PLR2004", # magic values in comparisons (HTTP status codes, small literals) are clear in context
+    "PLR0913", # API-wrapper functions legitimately take many arguments (service, playlist IDs, ...)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/yrt/__init__.py
+++ b/yrt/__init__.py
@@ -13,5 +13,5 @@ __all__ = [
     'models',
     'paths',
     'router',
-    'youtube'
+    'youtube',
 ]

--- a/yrt/analytics.py
+++ b/yrt/analytics.py
@@ -7,5 +7,5 @@ import pandas as pd
 pd.set_option('display.max_columns', None)  # pd.set_option('display.max_rows', None)
 pd.set_option('display.width', 250)
 
-if __name__ == "__main__":
-    print('Hello world :)')
+if __name__ == '__main__':
+    print('Hello world :)')  # noqa: T201

--- a/yrt/config.py
+++ b/yrt/config.py
@@ -1,8 +1,7 @@
 """Centralized configuration loading with defaults fallback."""
 
 # Local
-from . import paths
-from . import file_utils
+from . import file_utils, paths
 from .exceptions import ConfigurationError
 from .logging_utils import create_file_logger
 
@@ -11,25 +10,11 @@ logger = create_file_logger('config', paths.HISTORY_LOG)
 
 # Default configuration values (used if constants.json is missing or incomplete)
 DEFAULTS = {
-    'api': {
-        'batch_size': 50,
-        'max_retries': 3,
-        'base_delay_seconds': 1,
-        'max_backoff_seconds': 32
-    },
-    'network': {
-        'timeout_seconds': 5
-    },
-    'playlists': {
-        'release_radar_target_size': 40,
-        'relistening_age_weeks': 1
-    },
-    'video': {
-        'long_video_threshold_minutes': 10
-    },
-    'stats': {
-        'week_deltas': [1, 4, 12, 24]
-    }
+    'api': {'batch_size': 50, 'max_retries': 3, 'base_delay_seconds': 1, 'max_backoff_seconds': 32},
+    'network': {'timeout_seconds': 5},
+    'playlists': {'release_radar_target_size': 40, 'relistening_age_weeks': 1},
+    'video': {'long_video_threshold_minutes': 10},
+    'stats': {'week_deltas': [1, 4, 12, 24]},
 }
 
 

--- a/yrt/constants.py
+++ b/yrt/constants.py
@@ -16,17 +16,21 @@ STATUS_PRIVATE = 'private'
 STATUS_DELETED = 'deleted'
 
 # === API Error Categories (frozen sets for immutability) ===
-TRANSIENT_ERRORS = frozenset({
-    'serviceunavailable',
-    'backenderror',
-    'internalerror',
-})
-PERMANENT_ERRORS = frozenset({
-    'videonotfound',
-    'forbidden',
-    'playlistoperationunsupported',
-    'duplicate',
-})
+TRANSIENT_ERRORS = frozenset(
+    {
+        'serviceunavailable',
+        'backenderror',
+        'internalerror',
+    }
+)
+PERMANENT_ERRORS = frozenset(
+    {
+        'videonotfound',
+        'forbidden',
+        'playlistoperationunsupported',
+        'duplicate',
+    }
+)
 QUOTA_ERRORS = frozenset({'quotaexceeded'})
 
 # === Date/Time Formats ===

--- a/yrt/file_utils.py
+++ b/yrt/file_utils.py
@@ -76,22 +76,22 @@ def load_json(file_path: str, required_keys: list[str] | None = None) -> dict[st
     file_name = os.path.basename(file_path)
 
     try:
-        with open(validated_path, 'r', encoding='utf8') as f:
+        with open(validated_path, encoding='utf8') as f:
             data = json.load(f)
 
     except FileNotFoundError:
         logger.critical('%s not found. Expected location: %s', file_name, file_path)
         logger.critical('Please ensure all required files exist.')
-        raise ConfigurationError(f'{file_name} not found at {file_path}')
+        raise ConfigurationError(f'{file_name} not found at {file_path}') from None
 
     except json.JSONDecodeError as e:
         logger.critical('%s is malformed: %s', file_name, str(e))
         logger.critical('Please check the JSON syntax.')
-        raise ConfigurationError(f'{file_name} is malformed: {e}')
+        raise ConfigurationError(f'{file_name} is malformed: {e}') from e
 
     except Exception as e:
         logger.critical('Unexpected error loading %s: %s', file_name, str(e))
-        raise ConfigurationError(f'Unexpected error loading {file_name}: {e}')
+        raise ConfigurationError(f'Unexpected error loading {file_name}: {e}') from e
 
     # Validate required keys if specified
     if required_keys:
@@ -122,13 +122,13 @@ def save_json(file_path: str, data: dict[str, Any], indent: int = 2) -> None:
         with open(validated_path, 'w', encoding='utf-8') as f:
             json.dump(data, f, ensure_ascii=False, indent=indent)
 
-    except IOError as e:
+    except OSError as e:
         logger.critical('Failed to write %s: %s', file_name, str(e))
-        raise ConfigurationError(f'Failed to write {file_name}: {e}')
+        raise ConfigurationError(f'Failed to write {file_name}: {e}') from e
 
     except Exception as e:
         logger.critical('Unexpected error saving %s: %s', file_name, str(e))
-        raise ConfigurationError(f'Unexpected error saving {file_name}: {e}')
+        raise ConfigurationError(f'Unexpected error saving {file_name}: {e}') from e
 
 
 def validate_nested_keys(data: dict[str, Any], key_path: list[str], file_name: str) -> None:

--- a/yrt/logging_utils.py
+++ b/yrt/logging_utils.py
@@ -7,10 +7,7 @@ from pathlib import Path
 
 
 def create_file_logger(
-        name: str,
-        log_file: Path,
-        level: int = logging.DEBUG,
-        respect_no_logging: bool = True
+    name: str, log_file: Path, level: int = logging.DEBUG, respect_no_logging: bool = True
 ) -> logging.Logger:
     """Create a standardized file logger.
 
@@ -31,10 +28,7 @@ def create_file_logger(
     handler = logging.FileHandler(filename=log_file)
     handler.setLevel(level)
 
-    formatter = logging.Formatter(
-        fmt='%(asctime)s [%(levelname)s] - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S%z'
-    )
+    formatter = logging.Formatter(fmt='%(asctime)s [%(levelname)s] - %(message)s', datefmt='%Y-%m-%d %H:%M:%S%z')
 
     handler.setFormatter(formatter)
     logger.addHandler(handler)

--- a/yrt/main.py
+++ b/yrt/main.py
@@ -398,9 +398,8 @@ def main(historical_data: pd.DataFrame) -> None:
         youtube.encode_key(json_path=str(paths.CREDENTIALS_JSON))
         youtube.encode_key(json_path=str(paths.OAUTH_JSON))
 
-    else:  # Credentials in base64 update - Remote option
-        if creds_b64 is not None:
-            update_repo_secrets(secret_name=CREDS_ENV_NAME, new_value=creds_b64, logger=history_main)
+    elif creds_b64 is not None:
+        update_repo_secrets(secret_name=CREDS_ENV_NAME, new_value=creds_b64, logger=history_main)
 
     history_main.info('Process ended.')  # End
     copy_last_exe_log()  # Copy what happened during process execution to the associated file.

--- a/yrt/main.py
+++ b/yrt/main.py
@@ -5,21 +5,19 @@ import logging
 import os
 import re
 import sys
+from typing import cast
 
 # Third-party
 import github
 import pandas as pd
 
 # Local
-from . import config
-from . import file_utils
-from . import paths
-from . import youtube
+from . import config, file_utils, paths, youtube
 from .constants import LIVE_STATUS_UPCOMING
-from .exceptions import YouTubeTrackerError, GitHubError
+from .exceptions import GitHubError, YouTubeTrackerError
 from .logging_utils import create_file_logger
-from .models import PlaylistConfig, AddOnConfig
-from .router import create_router_from_config, set_default_router, dest_playlist
+from .models import AddOnConfig, PlaylistConfig
+from .router import create_router_from_config, dest_playlist, set_default_router
 
 # System
 
@@ -28,6 +26,9 @@ try:
 
 except IndexError:
     exe_mode = 'local'
+
+# Name of the GitHub repository secret holding the base64-encoded credentials
+CREDS_ENV_NAME = 'CREDS_B64'
 
 
 def _get_env_variables() -> tuple[str, str]:
@@ -47,17 +48,17 @@ def _get_env_variables() -> tuple[str, str]:
 
         # Validate that the values are not empty
         if not repo or not pat:
-            raise ValueError("Environment variables are empty")
+            raise ValueError('Environment variables are empty')
 
         return repo, pat
 
     except (KeyError, ValueError) as er:
         if exe_mode == 'action':
-            missing_var = str(er).replace("'", "") if isinstance(er, KeyError) else "GITHUB_REPOSITORY or PAT"
+            missing_var = str(er).replace("'", '') if isinstance(er, KeyError) else 'GITHUB_REPOSITORY or PAT'
             raise ConfigurationError(
-                f"Required environment variable {missing_var} not set or empty. "
-                f"Please configure GitHub repository secrets."
-            )
+                f'Required environment variable {missing_var} not set or empty. '
+                f'Please configure GitHub repository secrets.'
+            ) from er
         # Fall back to local mode defaults
         return 'Dyl-M/auto_youtube_playlist', 'PAT'
 
@@ -74,9 +75,16 @@ def _load_playlists_config() -> dict[str, PlaylistConfig]:
     playlists_data = file_utils.load_json(
         str(paths.PLAYLISTS_JSON),
         required_keys=[
-            'release', 'banger', 're_listening', 'legacy', 'apprentissage', 'divertissement_gaming', 'asmr',
-            'music_lives', 'regular_streams'
-        ]
+            'release',
+            'banger',
+            're_listening',
+            'legacy',
+            'apprentissage',
+            'divertissement_gaming',
+            'asmr',
+            'music_lives',
+            'regular_streams',
+        ],
     )
 
     return {
@@ -85,7 +93,7 @@ def _load_playlists_config() -> dict[str, PlaylistConfig]:
             name=data['name'],
             description=data['description'],
             retention_days=data.get('retention_days'),
-            cleanup_on_end=data.get('cleanup_on_end')
+            cleanup_on_end=data.get('cleanup_on_end'),
         )
         for name, data in playlists_data.items()
     }
@@ -97,16 +105,13 @@ def _load_addon_config() -> AddOnConfig:
     Returns:
         AddOnConfig instance with configuration data.
     """
-    add_on_data = file_utils.load_json(
-        str(paths.ADD_ON_JSON),
-        required_keys=['favorites']
-    )
+    add_on_data = file_utils.load_json(str(paths.ADD_ON_JSON), required_keys=['favorites'])
 
     return AddOnConfig(
         favorites=add_on_data['favorites'],
         playlist_not_found_pass=add_on_data.get('playlistNotFoundPass', []),
         to_pass=add_on_data.get('toPass', []),
-        certified=add_on_data.get('certified', [])
+        certified=add_on_data.get('certified', []),
     )
 
 
@@ -115,8 +120,7 @@ github_repo, PAT = _get_env_variables()
 
 # Load configuration files with validation
 pocket_tube = file_utils.load_json(
-    str(paths.POCKET_TUBE_JSON),
-    required_keys=['MUSIQUE', 'APPRENTISSAGE', 'DIVERTISSEMENT', 'GAMING']
+    str(paths.POCKET_TUBE_JSON), required_keys=['MUSIQUE', 'APPRENTISSAGE', 'DIVERTISSEMENT', 'GAMING']
 )
 
 playlists = _load_playlists_config()
@@ -127,8 +131,9 @@ favorites = add_on.favorites.values()
 
 # YouTube Channels list
 music = pocket_tube['MUSIQUE']
-other_raw = (pocket_tube['APPRENTISSAGE'] + pocket_tube['DIVERTISSEMENT'] +
-             pocket_tube['GAMING'] + pocket_tube.get('ASMR', []))
+other_raw = (
+    pocket_tube['APPRENTISSAGE'] + pocket_tube['DIVERTISSEMENT'] + pocket_tube['GAMING'] + pocket_tube.get('ASMR', [])
+)
 other = list(set(other_raw))
 all_channels = list(set(music + other))
 
@@ -177,11 +182,30 @@ if os.path.exists(paths.STATS_CSV):
     histo_data = pd.read_csv(paths.STATS_CSV, encoding='utf-8')
 
 else:
-    print("INFO: stats.csv not found. Creating new empty DataFrame.")
+    print('INFO: stats.csv not found. Creating new empty DataFrame.')
     # Create empty DataFrame with correct schema
-    columns = ['video_id', 'channel_id', 'release_date', 'status', 'is_shorts', 'duration', 'views_w1', 'views_w4',
-               'views_w12', 'views_w24', 'likes_w1', 'likes_w4', 'likes_w12', 'likes_w24', 'comments_w1', 'comments_w4',
-               'comments_w12', 'comments_w24', 'channel_name', 'video_title']
+    columns = [
+        'video_id',
+        'channel_id',
+        'release_date',
+        'status',
+        'is_shorts',
+        'duration',
+        'views_w1',
+        'views_w4',
+        'views_w12',
+        'views_w24',
+        'likes_w1',
+        'likes_w4',
+        'likes_w12',
+        'likes_w24',
+        'comments_w1',
+        'comments_w4',
+        'comments_w12',
+        'comments_w24',
+        'channel_name',
+        'video_title',
+    ]
     histo_data = pd.DataFrame(columns=columns)
 
 
@@ -190,10 +214,10 @@ else:
 
 def copy_last_exe_log() -> None:
     """Copy the last execution logging from the main history file."""
-    with open(paths.HISTORY_LOG, 'r', encoding='utf8') as history_file:
+    with open(paths.HISTORY_LOG, encoding='utf8') as history_file:
         history = history_file.read()
 
-    last_exe = re.findall(r".*?Process started\.", history)[-1]
+    last_exe = re.findall(r'.*?Process started\.', history)[-1]
     last_exe_idx = history.rfind(last_exe)
     last_exe_log = history[last_exe_idx:]
 
@@ -221,19 +245,12 @@ def _update_historical_stats(service: youtube.pyt.Client, historical_data: pd.Da
         Updated DataFrame with collected stats.
     """
     for week_delta in config.STATS_WEEK_DELTAS:
-        historical_data = youtube.weekly_stats(
-            service=service,
-            histo_data=historical_data,
-            week_delta=week_delta
-        )
+        historical_data = youtube.weekly_stats(service=service, histo_data=historical_data, week_delta=week_delta)
     return historical_data
 
 
 def _add_videos_to_playlists(
-        service: youtube.pyt.Client,
-        to_add: dict[str, list[str]],
-        logger: logging.Logger,
-        prog_bar: bool
+    service: youtube.pyt.Client, to_add: dict[str, list[str]], logger: logging.Logger, prog_bar: bool
 ) -> None:
     """Add videos to their destination playlists.
 
@@ -274,9 +291,9 @@ def update_repo_secrets(secret_name: str, new_value: str, logger: logging.Logger
             logger.error("Failed to update Repository Secret '%s' : %s", secret_name, error)
 
         else:
-            print(f"Failed to update secret {secret_name}. Error: {error}")
+            print(f'Failed to update secret {secret_name}. Error: {error}')
 
-        raise GitHubError(f"Failed to update Repository Secret '{secret_name}': {error}")
+        raise GitHubError(f"Failed to update Repository Secret '{secret_name}': {error}") from error
 
 
 def main(historical_data: pd.DataFrame) -> None:
@@ -324,13 +341,33 @@ def main(historical_data: pd.DataFrame) -> None:
             history_main.info('Filtered %d upcoming stream(s) from stats tracking.', upcoming_mask.sum())
 
         # Prepare data for storing (excluding upcoming streams)
-        to_keep = ['video_id', 'channel_id', 'release_date', 'status', 'is_shorts', 'duration', 'channel_name',
-                   'video_title']
-        stats_list = ['views_w1', 'views_w4', 'views_w12', 'views_w24', 'likes_w1', 'likes_w4', 'likes_w12',
-                      'likes_w24', 'comments_w1', 'comments_w4', 'comments_w12', 'comments_w24']
+        to_keep = [
+            'video_id',
+            'channel_id',
+            'release_date',
+            'status',
+            'is_shorts',
+            'duration',
+            'channel_name',
+            'video_title',
+        ]
+        stats_list = [
+            'views_w1',
+            'views_w4',
+            'views_w12',
+            'views_w24',
+            'likes_w1',
+            'likes_w4',
+            'likes_w12',
+            'likes_w24',
+            'comments_w1',
+            'comments_w4',
+            'comments_w12',
+            'comments_w24',
+        ]
 
         stored = new_data[~upcoming_mask][to_keep]
-        stored.loc[:, stats_list] = [pd.NA] * len(stats_list)  # type: ignore[assignment]
+        stored.loc[:, stats_list] = [pd.NA] * len(stats_list)
         stored = stored[to_keep[:-2] + stats_list + to_keep[-2:]]
 
         # Sort and store (drop all-NA columns before concat to avoid FutureWarning)
@@ -339,23 +376,17 @@ def main(historical_data: pd.DataFrame) -> None:
         stored.to_csv(paths.STATS_CSV, encoding='utf-8', index=False)
 
         # Define destination playlist (use source_channel_id to handle YouTube's auto-generated artist channels)
-        new_data['dest_playlist'] = new_data.apply(lambda row: dest_playlist(row.source_channel_id,
-                                                                             row.is_shorts,
-                                                                             row.duration,
-                                                                             row.live_status), axis=1)
+        new_data['dest_playlist'] = new_data.apply(
+            lambda row: dest_playlist(row.source_channel_id, row.is_shorts, row.duration, row.live_status), axis=1
+        )
 
         # Add videos to playlists
-        to_add = new_data.groupby('dest_playlist')['video_id'].apply(list).to_dict()
+        # noinspection PyTypeChecker
+        to_add = cast('dict[str, list[str]]', new_data.groupby('dest_playlist')['video_id'].apply(list).to_dict())
         _add_videos_to_playlists(youtube_oauth, to_add, history_main, prog_bar)
 
     # Fill the Release Radar playlist (uses config.RELEASE_RADAR_TARGET by default)
-    youtube.fill_release_radar(
-        youtube_oauth,
-        release,
-        re_listening,
-        legacy,
-        prog_bar=prog_bar
-    )
+    youtube.fill_release_radar(youtube_oauth, release, re_listening, legacy, prog_bar=prog_bar)
 
     # Cleanup expired videos from category playlists
     youtube.cleanup_expired_videos(youtube_oauth, playlists, prog_bar=prog_bar)
@@ -369,7 +400,7 @@ def main(historical_data: pd.DataFrame) -> None:
 
     else:  # Credentials in base64 update - Remote option
         if creds_b64 is not None:
-            update_repo_secrets(secret_name='CREDS_B64', new_value=creds_b64, logger=history_main)
+            update_repo_secrets(secret_name=CREDS_ENV_NAME, new_value=creds_b64, logger=history_main)
 
     history_main.info('Process ended.')  # End
     copy_last_exe_log()  # Copy what happened during process execution to the associated file.

--- a/yrt/models.py
+++ b/yrt/models.py
@@ -1,13 +1,12 @@
 """Domain models for YouTube Release Tracker."""
 
 # Standard library
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any
 
 # Local
 from .constants import LIVE_STATUS_NONE, STATUS_PUBLIC
-
 
 # === Configuration Models ===
 
@@ -33,11 +32,11 @@ class PlaylistConfig:
     def __post_init__(self) -> None:
         """Validate playlist configuration."""
         if not self.id:
-            raise ValueError("Playlist ID cannot be empty")
+            raise ValueError('Playlist ID cannot be empty')
         if not self.name:
-            raise ValueError("Playlist name cannot be empty")
+            raise ValueError('Playlist name cannot be empty')
         if self.retention_days is not None and self.retention_days < 0:
-            raise ValueError(f"retention_days must be >= 0, got {self.retention_days}")
+            raise ValueError(f'retention_days must be >= 0, got {self.retention_days}')
 
 
 @dataclass
@@ -59,7 +58,7 @@ class AddOnConfig:
     def __post_init__(self) -> None:
         """Validate add-on configuration."""
         if not isinstance(self.favorites, dict):
-            raise ValueError("favorites must be a dict")
+            raise ValueError('favorites must be a dict')
 
 
 # === Video/Playlist Item Models ===
@@ -92,9 +91,9 @@ class PlaylistItem:
     def __post_init__(self) -> None:
         """Validate required fields."""
         if not self.video_id:
-            raise ValueError("video_id cannot be empty")
+            raise ValueError('video_id cannot be empty')
         if not self.source_channel_id:
-            raise ValueError("source_channel_id cannot be empty")
+            raise ValueError('source_channel_id cannot be empty')
 
 
 @dataclass
@@ -124,7 +123,7 @@ class VideoStats:
     def __post_init__(self) -> None:
         """Validate video ID."""
         if not self.video_id:
-            raise ValueError("video_id cannot be empty")
+            raise ValueError('video_id cannot be empty')
 
 
 @dataclass
@@ -170,9 +169,7 @@ class VideoData:
     dest_playlist: str | None = None
 
     @classmethod
-    def from_playlist_item_and_stats(
-            cls, item: PlaylistItem, stats: VideoStats
-    ) -> 'VideoData':
+    def from_playlist_item_and_stats(cls, item: PlaylistItem, stats: VideoStats) -> 'VideoData':
         """Merge PlaylistItem and VideoStats into VideoData.
 
         Args:
@@ -218,9 +215,9 @@ class PlaylistItemRef:
     def __post_init__(self) -> None:
         """Validate required fields."""
         if not self.item_id:
-            raise ValueError("item_id cannot be empty")
+            raise ValueError('item_id cannot be empty')
         if not self.video_id:
-            raise ValueError("video_id cannot be empty")
+            raise ValueError('video_id cannot be empty')
 
 
 # === Helper Functions ===
@@ -240,8 +237,8 @@ def to_dict(obj: Any) -> dict[str, Any]:
     """
     from dataclasses import is_dataclass
 
-    if not is_dataclass(obj):
-        raise TypeError(f"Expected dataclass, got {type(obj)}")
+    if not is_dataclass(obj) or isinstance(obj, type):
+        raise TypeError(f'Expected dataclass instance, got {type(obj)}')
 
     result = asdict(obj)
 

--- a/yrt/router.py
+++ b/yrt/router.py
@@ -5,17 +5,17 @@ from dataclasses import dataclass
 
 # Local
 from .constants import (
-    ROUTING_SHORTS,
-    ROUTING_NONE,
-    LIVE_STATUS_UPCOMING,
-    CATEGORY_MUSIC,
-    CATEGORY_LEARNING,
+    CATEGORY_ASMR,
     CATEGORY_ENTERTAINMENT,
     CATEGORY_GAMING,
-    CATEGORY_ASMR,
+    CATEGORY_LEARNING,
+    CATEGORY_MUSIC,
     CATEGORY_PRIORITY,
+    LIVE_STATUS_UPCOMING,
+    ROUTING_NONE,
+    ROUTING_SHORTS,
 )
-from .models import PlaylistConfig, AddOnConfig
+from .models import AddOnConfig, PlaylistConfig
 
 # Module-level default router (set by main.py after config loading)
 _default_router: 'VideoRouter | None' = None
@@ -63,10 +63,10 @@ class RouterConfig:
 
         for name, value in required_ids:
             if not value:
-                raise ValueError(f"{name} cannot be empty")
+                raise ValueError(f'{name} cannot be empty')
 
         if self.long_video_threshold_minutes <= 0:
-            raise ValueError("long_video_threshold_minutes must be positive")
+            raise ValueError('long_video_threshold_minutes must be positive')
 
 
 # === Router Class ===
@@ -100,8 +100,7 @@ class VideoRouter:
         """
         self.config = config
 
-    def route(self, channel_id: str, is_shorts: bool | None,
-              duration: int | None, live_status: str = 'none') -> str:
+    def route(self, channel_id: str, is_shorts: bool | None, duration: int | None, live_status: str = 'none') -> str:
         """Determine destination playlist for a video.
 
         Args:
@@ -185,8 +184,7 @@ class VideoRouter:
             return self.config.category_playlists[category]
         return self.SPECIAL_NONE
 
-    def _route_music(self, channel_id: str, is_long: bool,
-                     non_music_category: str | None) -> str:
+    def _route_music(self, channel_id: str, is_long: bool, non_music_category: str | None) -> str:
         """Route music channel video to appropriate playlist.
 
         Args:
@@ -210,8 +208,7 @@ class VideoRouter:
         # Regular music goes to Release Radar
         return self.config.release_radar_id
 
-    def __call__(self, channel_id: str, is_shorts: bool | None,
-                 duration: int | None, live_status: str = 'none') -> str:
+    def __call__(self, channel_id: str, is_shorts: bool | None, duration: int | None, live_status: str = 'none') -> str:
         """Allow router instance to be called like a function.
 
         This enables backward-compatible usage as a drop-in replacement
@@ -233,10 +230,10 @@ class VideoRouter:
 
 
 def create_router_from_config(
-        pocket_tube: dict[str, list[str]],
-        playlists: dict[str, PlaylistConfig],
-        add_on: AddOnConfig,
-        long_video_threshold: int | None = None
+    pocket_tube: dict[str, list[str]],
+    playlists: dict[str, PlaylistConfig],
+    add_on: AddOnConfig,
+    long_video_threshold: int | None = None,
 ) -> VideoRouter:
     """Create a VideoRouter from configuration objects.
 
@@ -273,7 +270,7 @@ def create_router_from_config(
         banger_radar_id=playlists['banger'].id,
         music_lives_id=playlists['music_lives'].id,
         regular_streams_id=playlists['regular_streams'].id,
-        long_video_threshold_minutes=threshold
+        long_video_threshold_minutes=threshold,
     )
 
     return VideoRouter(router_config)
@@ -291,8 +288,7 @@ def set_default_router(router: VideoRouter) -> None:
     _default_router = router
 
 
-def dest_playlist(channel_id: str, is_shorts: bool | None, v_duration: int | None,
-                  live_status: str = 'none') -> str:
+def dest_playlist(channel_id: str, is_shorts: bool | None, v_duration: int | None, live_status: str = 'none') -> str:
     """Return destination playlist for addition based on channel category and video properties.
 
     This is a convenience function that uses the default router set by main.py.
@@ -321,11 +317,6 @@ def dest_playlist(channel_id: str, is_shorts: bool | None, v_duration: int | Non
         RuntimeError: If called before set_default_router().
     """
     if _default_router is None:
-        raise RuntimeError("Router not initialized. Call set_default_router() first.")
+        raise RuntimeError('Router not initialized. Call set_default_router() first.')
 
-    return _default_router.route(
-        channel_id,
-        is_shorts,
-        v_duration,
-        live_status
-    )
+    return _default_router.route(channel_id, is_shorts, v_duration, live_status)

--- a/yrt/youtube/__init__.py
+++ b/yrt/youtube/__init__.py
@@ -6,9 +6,9 @@ including authentication, video discovery, statistics collection, and playlist m
 
 # Third-party
 import pandas as pd
-import pyyoutube as pyt  # type: ignore[import-untyped]
+import pyyoutube as pyt
 
-# Local - for re-export
+# Local
 from .. import paths
 from ..logging_utils import create_file_logger
 
@@ -22,51 +22,46 @@ from . import utils  # noqa: E402
 utils.set_logger(history)
 
 # Import all public functions from submodules
-from .utils import (  # noqa: E402
-    last_exe_date,
-    is_shorts,
-    sort_db,
-    get_items_count,
-    # Constants and state
-    NOW,
-    LAST_EXE,
-    ADD_ON,
-    ISO_DATE_FORMAT,
-    TRANSIENT_ERRORS,
-    PERMANENT_ERRORS,
-    QUOTA_ERRORS,
-)
-
-from .auth import (  # noqa: E402
-    encode_key,
-    create_service_local,
-    create_service_workflow,
-)
-
 from .api import (  # noqa: E402
-    get_playlist_items,
-    get_videos,
-    get_subs,
     check_if_live,
+    get_playlist_items,
+    get_subs,
+    get_videos,
     iter_channels,
 )
-
-from .stats import (  # noqa: E402
-    get_stats,
-    add_stats,
-    weekly_stats,
+from .auth import (  # noqa: E402
+    create_service_local,
+    create_service_workflow,
+    encode_key,
 )
-
+from .cleanup import (  # noqa: E402
+    cleanup_ended_streams,
+    cleanup_expired_videos,
+)
 from .playlist import (  # noqa: E402
+    add_api_fail,
     add_to_playlist,
     del_from_playlist,
     fill_release_radar,
-    add_api_fail,
 )
-
-from .cleanup import (  # noqa: E402
-    cleanup_expired_videos,
-    cleanup_ended_streams,
+from .stats import (  # noqa: E402
+    add_stats,
+    get_stats,
+    weekly_stats,
+)
+from .utils import (  # noqa: E402
+    ADD_ON,
+    ISO_DATE_FORMAT,
+    LAST_EXE,
+    # Constants and state
+    NOW,
+    PERMANENT_ERRORS,
+    QUOTA_ERRORS,
+    TRANSIENT_ERRORS,
+    get_items_count,
+    is_shorts,
+    last_exe_date,
+    sort_db,
 )
 
 # Pandas options

--- a/yrt/youtube/api.py
+++ b/yrt/youtube/api.py
@@ -6,8 +6,8 @@ import itertools
 from typing import Any
 
 # Third-party
-import pyyoutube as pyt  # type: ignore[import-untyped]
-import tqdm  # type: ignore[import-untyped]
+import pyyoutube as pyt
+import tqdm
 
 # Local
 from .. import config
@@ -38,14 +38,12 @@ def _parse_playlist_item(item: Any, date_format: str, source_channel_id: str) ->
         status=item.status.privacyStatus,
         channel_id=item.snippet.videoOwnerChannelId,
         channel_name=item.snippet.videoOwnerChannelTitle,
-        source_channel_id=source_channel_id  # Set at creation - no mutation!
+        source_channel_id=source_channel_id,  # Set at creation - no mutation!
     )
 
 
 def _handle_playlist_error(
-        error: pyt.error.PyYouTubeException,
-        playlist_id: str,
-        add_on: dict[str, Any] | None = None
+    error: pyt.error.PyYouTubeException, playlist_id: str, add_on: dict[str, Any] | None = None
 ) -> bool:
     """Handle playlist API errors. Raises APIError for fatal errors.
 
@@ -75,10 +73,7 @@ def _handle_playlist_error(
 
 
 def _filter_items_by_date_range(
-        p_items: list[PlaylistItem],
-        latest_d: dt.datetime,
-        oldest_d: dt.datetime | None = None,
-        day_ago: int | None = None
+    p_items: list[PlaylistItem], latest_d: dt.datetime, oldest_d: dt.datetime | None = None, day_ago: int | None = None
 ) -> list[PlaylistItem]:
     """Filter videos on a date range.
 
@@ -100,11 +95,11 @@ def _filter_items_by_date_range(
 
 
 def get_playlist_items(
-        service: pyt.Client,
-        playlist_id: str,
-        source_channel_id: str,
-        day_ago: int | None = None,
-        latest_d: dt.datetime | None = None
+    service: pyt.Client,
+    playlist_id: str,
+    source_channel_id: str,
+    day_ago: int | None = None,
+    latest_d: dt.datetime | None = None,
 ) -> list[PlaylistItem]:
     """Get the videos in a YouTube playlist.
 
@@ -133,7 +128,7 @@ def get_playlist_items(
                 part=['snippet', 'contentDetails', 'status'],
                 playlist_id=playlist_id,
                 max_results=config.API_BATCH_SIZE,
-                pageToken=next_page_token
+                pageToken=next_page_token,
             )
 
             # Parse items, filtering out those without release date
@@ -170,7 +165,7 @@ def get_videos(service: pyt.Client, videos_list: list[str]) -> list[Any]:
     return service.videos.list(  # type: ignore[no-any-return]
         part=['snippet', 'contentDetails', 'statistics', 'status'],
         video_id=videos_list,
-        max_results=config.API_BATCH_SIZE
+        max_results=config.API_BATCH_SIZE,
     ).items
 
 
@@ -187,17 +182,13 @@ def get_subs(service: pyt.Client, channel_list: list[str]) -> list[dict[str, Any
     ch_filter = [channel_id for channel_id in channel_list if channel_id is not None]
 
     # Split task in chunks to request on a maximum of API_BATCH_SIZE channels at each iteration.
-    batch_size = config.API_BATCH_SIZE
-    channels_chunks = [ch_filter[i:i + min(batch_size, len(ch_filter))] for i in range(0, len(ch_filter), batch_size)]
     raw_chunk = []
 
-    for chunk in channels_chunks:
+    for chunk in utils.chunked(ch_filter, config.API_BATCH_SIZE):
         req = service.channels.list(part=['statistics'], channel_id=chunk, max_results=config.API_BATCH_SIZE).items
         raw_chunk += req
 
-    items = [{'channel_id': item.id, 'subscribers': item.statistics.subscriberCount} for item in raw_chunk]
-
-    return items
+    return [{'channel_id': item.id, 'subscribers': item.statistics.subscriberCount} for item in raw_chunk]
 
 
 def check_if_live(service: pyt.Client, videos_list: list[str]) -> list[dict[str, Any]]:
@@ -216,11 +207,7 @@ def check_if_live(service: pyt.Client, videos_list: list[str]) -> list[dict[str,
     items = []
 
     # Split tasks in chunks to request a maximum of API_BATCH_SIZE videos at each iteration.
-    batch_size = config.API_BATCH_SIZE
-    videos_chunks = [videos_list[i:i + min(batch_size, len(videos_list))]
-                     for i in range(0, len(videos_list), batch_size)]
-
-    for chunk in videos_chunks:
+    for chunk in utils.chunked(videos_list, config.API_BATCH_SIZE):
         try:
             request = get_videos(service=service, videos_list=chunk)
 
@@ -230,17 +217,17 @@ def check_if_live(service: pyt.Client, videos_list: list[str]) -> list[dict[str,
         except pyt.error.PyYouTubeException as api_error:
             if utils.history:
                 utils.history.error(api_error.message)
-            raise APIError(f'API error while checking live status: {api_error.message}')
+            raise APIError(f'API error while checking live status: {api_error.message}') from api_error
 
     return items
 
 
 def iter_channels(
-        service: pyt.Client,
-        channels: list[str],
-        day_ago: int | None = None,
-        latest_d: dt.datetime | None = None,
-        prog_bar: bool = True
+    service: pyt.Client,
+    channels: list[str],
+    day_ago: int | None = None,
+    latest_d: dt.datetime | None = None,
+    prog_bar: bool = True,
 ) -> list[PlaylistItem]:
     """Apply 'get_playlist_items' for a collection of YouTube playlists.
 
@@ -268,8 +255,7 @@ def iter_channels(
 
     else:
         item_it = [
-            get_playlist_items(service, pl_id, ch_id, day_ago, latest_d)
-            for ch_id, pl_id in channel_playlist_pairs
+            get_playlist_items(service, pl_id, ch_id, day_ago, latest_d) for ch_id, pl_id in channel_playlist_pairs
         ]
 
     return list(itertools.chain.from_iterable(item_it))

--- a/yrt/youtube/auth.py
+++ b/yrt/youtube/auth.py
@@ -8,15 +8,21 @@ import os
 from typing import Any
 
 # Third-party
-import pyyoutube as pyt  # type: ignore[import-untyped]
+import pyyoutube as pyt
+
+# noinspection PyPackageRequirements
 from google.auth.exceptions import RefreshError
+
+# noinspection PyPackageRequirements
 from google.auth.transport.requests import Request
+
+# noinspection PyPackageRequirements
 from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore[import-untyped]
+from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Local
 from .. import paths
-from ..exceptions import CredentialsError, YouTubeServiceError, FileAccessError
+from ..exceptions import CredentialsError, FileAccessError, YouTubeServiceError
 from . import utils
 
 
@@ -50,7 +56,7 @@ def encode_key(json_path: str, export_dir: str | None = None, export_name: str |
             utils.history.error('%s file does not exist.', json_path)
         raise FileAccessError(f'{json_path} file does not exist.')
 
-    with open(json_path, 'r', encoding='utf8') as json_file:
+    with open(json_path, encoding='utf8') as json_file:
         key_dict = json.load(json_file)
 
     key_str = json.dumps(key_dict).encode('utf-8')
@@ -113,7 +119,7 @@ def create_service_local(log: bool = True) -> pyt.Client:
         if log and utils.history:
             utils.history.critical('(%s) %s', error, instance_fail_message)
 
-        raise YouTubeServiceError(f'{instance_fail_message}: {error}')
+        raise YouTubeServiceError(f'{instance_fail_message}: {error}') from error
 
 
 def create_service_workflow() -> tuple[pyt.Client, str]:
@@ -143,8 +149,8 @@ def create_service_workflow() -> tuple[pyt.Client, str]:
         if v_b64 is None:
             raise CredentialsError(f'Environment variable {var_name} not found')
         v_str = base64.urlsafe_b64decode(v_b64).decode(encoding='utf8')  # Decode
-        value = ast.literal_eval(v_str)  # Eval
-        return value  # type: ignore[no-any-return]
+        decoded: dict[str, Any] = ast.literal_eval(v_str)  # Eval
+        return decoded
 
     creds_b64 = os.environ.get('CREDS_B64')  # Initiate the Base64 version of the Credentials object
     creds_dict = import_env_var(var_name='CREDS_B64')  # Import pre-registered credentials
@@ -172,11 +178,12 @@ def create_service_workflow() -> tuple[pyt.Client, str]:
         service = pyt.Client(client_id=creds.client_id, client_secret=creds.client_secret, access_token=creds.token)
         if utils.history:
             utils.history.info('YouTube service created successfully.')
-        # creds_b64 is guaranteed to be str at this point (import_env_var raises if missing)
-        assert creds_b64 is not None
+        # creds_b64 is guaranteed to be str at this point (import_env_var raises if missing); guard narrows the type
+        if creds_b64 is None:
+            raise CredentialsError('CREDS_B64 environment variable not found')
         return service, creds_b64
 
     except (pyt.error.PyYouTubeException, ValueError, AttributeError) as error:
         if utils.history:
             utils.history.critical('(%s) %s', error, instance_fail_message)
-        raise YouTubeServiceError(f'{instance_fail_message}: {error}')
+        raise YouTubeServiceError(f'{instance_fail_message}: {error}') from error

--- a/yrt/youtube/cleanup.py
+++ b/yrt/youtube/cleanup.py
@@ -4,7 +4,7 @@
 import datetime as dt
 
 # Third-party
-import pyyoutube as pyt  # type: ignore[import-untyped]
+import pyyoutube as pyt
 
 # Local
 from .. import config
@@ -35,12 +35,11 @@ def _fetch_stream_playlist_items(service: pyt.Client, playlist_id: str, playlist
                 part=['snippet', 'contentDetails'],
                 playlist_id=playlist_id,
                 max_results=config.API_BATCH_SIZE,
-                pageToken=next_page_token
+                pageToken=next_page_token,
             )
 
             all_items.extend(
-                PlaylistItemRef(item_id=item.id, video_id=item.contentDetails.videoId)
-                for item in response.items
+                PlaylistItemRef(item_id=item.id, video_id=item.contentDetails.videoId) for item in response.items
             )
 
             next_page_token = response.nextPageToken
@@ -60,10 +59,7 @@ def _fetch_stream_playlist_items(service: pyt.Client, playlist_id: str, playlist
 
 
 def _fetch_expired_items(
-        service: pyt.Client,
-        playlist_id: str,
-        playlist_name: str,
-        cutoff_date: dt.datetime
+    service: pyt.Client, playlist_id: str, playlist_name: str, cutoff_date: dt.datetime
 ) -> list[PlaylistItemRef]:
     """Fetch items from a playlist that are older than the cutoff date.
 
@@ -85,7 +81,7 @@ def _fetch_expired_items(
                 part=['snippet', 'contentDetails'],
                 playlist_id=playlist_id,
                 max_results=config.API_BATCH_SIZE,
-                pageToken=next_page_token
+                pageToken=next_page_token,
             )
 
             for item in response.items:
@@ -95,11 +91,7 @@ def _fetch_expired_items(
                     added_date = dt.datetime.strptime(added_date_str, utils.ISO_DATE_FORMAT)
                     if added_date < cutoff_date:
                         expired_items.append(
-                            PlaylistItemRef(
-                                item_id=item.id,
-                                video_id=item.contentDetails.videoId,
-                                add_date=added_date
-                            )
+                            PlaylistItemRef(item_id=item.id, video_id=item.contentDetails.videoId, add_date=added_date)
                         )
 
             next_page_token = response.nextPageToken
@@ -135,9 +127,7 @@ def _find_ended_streams(service: pyt.Client, all_items: list[PlaylistItemRef]) -
     ended_items: list[PlaylistItemRef] = []
 
     # Batch video status checks
-    batch_size = config.API_BATCH_SIZE
-    for i in range(0, len(video_ids), batch_size):
-        chunk = video_ids[i:i + batch_size]
+    for chunk in utils.chunked(video_ids, config.API_BATCH_SIZE):
         try:
             videos_response = get_videos(service=service, videos_list=chunk)
             for video in videos_response:
@@ -152,9 +142,7 @@ def _find_ended_streams(service: pyt.Client, all_items: list[PlaylistItemRef]) -
 
 
 def cleanup_expired_videos(
-        service: pyt.Client,
-        playlist_config: dict[str, PlaylistConfig],
-        prog_bar: bool = True
+    service: pyt.Client, playlist_config: dict[str, PlaylistConfig], prog_bar: bool = True
 ) -> None:
     """Remove expired videos from playlists with retention rules.
 
@@ -179,17 +167,10 @@ def cleanup_expired_videos(
 
         if utils.history:
             utils.history.info(
-                'Checking retention for playlist "%s" (retention: %d days)',
-                playlist_name,
-                playlist_cfg.retention_days
+                'Checking retention for playlist "%s" (retention: %d days)', playlist_name, playlist_cfg.retention_days
             )
 
-        expired_items = _fetch_expired_items(
-            service,
-            playlist_id,
-            playlist_name,
-            cutoff_date
-        )
+        expired_items = _fetch_expired_items(service, playlist_id, playlist_name, cutoff_date)
 
         if expired_items:
             if utils.history:
@@ -202,9 +183,7 @@ def cleanup_expired_videos(
 
 
 def cleanup_ended_streams(
-        service: pyt.Client,
-        playlist_config: dict[str, PlaylistConfig],
-        prog_bar: bool = True
+    service: pyt.Client, playlist_config: dict[str, PlaylistConfig], prog_bar: bool = True
 ) -> None:
     """Remove ended streams from playlists with cleanup_on_end=True.
 

--- a/yrt/youtube/cleanup.py
+++ b/yrt/youtube/cleanup.py
@@ -50,9 +50,8 @@ def _fetch_stream_playlist_items(service: pyt.Client, playlist_id: str, playlist
             if error.status_code == 403:
                 if utils.history:
                     utils.history.warning('API quota exceeded while checking streams for %s', playlist_name)
-            else:
-                if utils.history:
-                    utils.history.warning('Error fetching items from %s: %s', playlist_name, error.message)
+            elif utils.history:
+                utils.history.warning('Error fetching items from %s: %s', playlist_name, error.message)
             break
 
     return all_items
@@ -103,9 +102,8 @@ def _fetch_expired_items(
                 if utils.history:
                     utils.history.warning('API quota exceeded while checking retention for %s', playlist_name)
 
-            else:
-                if utils.history:
-                    utils.history.warning('Error fetching items from %s: %s', playlist_name, error.message)
+            elif utils.history:
+                utils.history.warning('Error fetching items from %s: %s', playlist_name, error.message)
 
             break
 
@@ -222,6 +220,5 @@ def cleanup_ended_streams(
                 utils.history.info('Removing %d ended stream(s) from "%s"', len(ended_items), playlist_name)
             del_from_playlist(service, playlist_id, ended_items, prog_bar)
 
-        else:
-            if utils.history:
-                utils.history.info('No ended streams in "%s"', playlist_name)
+        elif utils.history:
+            utils.history.info('No ended streams in "%s"', playlist_name)

--- a/yrt/youtube/playlist.py
+++ b/yrt/youtube/playlist.py
@@ -8,23 +8,16 @@ import time
 from typing import Any
 
 # Third-party
-import pyyoutube as pyt  # type: ignore[import-untyped]
-import tqdm  # type: ignore[import-untyped]
+import pyyoutube as pyt
+import tqdm
 
 # Local
-from .. import config
-from .. import file_utils
-from .. import paths
+from .. import config, file_utils, paths
 from ..models import PlaylistItemRef
 from . import utils
 
 
-def add_to_playlist(
-        service: pyt.Client,
-        playlist_id: str,
-        videos_list: list[str],
-        prog_bar: bool = True
-) -> None:
+def add_to_playlist(service: pyt.Client, playlist_id: str, videos_list: list[str], prog_bar: bool = True) -> None:
     """Add a list of video to a YouTube playlist.
 
     Args:
@@ -62,24 +55,35 @@ def add_to_playlist(
                 if error_reason_normalized in utils.TRANSIENT_ERRORS and attempt < config.MAX_RETRIES - 1:
                     # Calculate exponential backoff with equal jitter to prevent thundering herd
                     delay = min(config.MAX_BACKOFF, int(config.BASE_DELAY * math.exp(attempt)))
-                    wait_time = delay / 2 + random.uniform(0, delay / 2)
+                    wait_time = delay / 2 + random.uniform(0, delay / 2)  # noqa: S311
                     if utils.history:
-                        utils.history.warning('Transient error (%s) for video %s, retrying in %.2fs (attempt %s/%s)',
-                                              error_reason, video_id, wait_time, attempt + 1, config.MAX_RETRIES)
+                        utils.history.warning(
+                            'Transient error (%s) for video %s, retrying in %.2fs (attempt %s/%s)',
+                            error_reason,
+                            video_id,
+                            wait_time,
+                            attempt + 1,
+                            config.MAX_RETRIES,
+                        )
                     time.sleep(wait_time)
                     continue
 
                 # Handle permanent errors - log and skip, don't save for retry
                 if error_reason_normalized in utils.PERMANENT_ERRORS:
                     if utils.history:
-                        utils.history.warning('Permanent error (%s) for video %s - skipping: %s',
-                                              error_reason, video_id, http_error.message)
+                        utils.history.warning(
+                            'Permanent error (%s) for video %s - skipping: %s',
+                            error_reason,
+                            video_id,
+                            http_error.message,
+                        )
                     break  # Don't save to api_failure.json
 
                 # Handle quota errors or failed transient retries - save for next day retry
                 if utils.history:
-                    utils.history.warning('Addition Request Failure: (%s) - %s - %s',
-                                          video_id, error_reason, http_error.message)
+                    utils.history.warning(
+                        'Addition Request Failure: (%s) - %s - %s', video_id, error_reason, http_error.message
+                    )
                 api_failure[playlist_id]['failure'].append(video_id)
                 api_fail = True
                 break
@@ -89,10 +93,10 @@ def add_to_playlist(
 
 
 def del_from_playlist(
-        service: pyt.Client,
-        playlist_id: str,
-        items_list: list[PlaylistItemRef] | list[dict[str, Any]],
-        prog_bar: bool = True
+    service: pyt.Client,
+    playlist_id: str,
+    items_list: list[PlaylistItemRef] | list[dict[str, Any]],
+    prog_bar: bool = True,
 ) -> None:
     """Delete videos inside a YouTube playlist.
 
@@ -103,6 +107,7 @@ def del_from_playlist(
         prog_bar: Whether to use tqdm progress bar.
     """
     if prog_bar:
+        # noinspection PyTypeChecker
         del_iterator = tqdm.tqdm(items_list, desc=f'Deleting videos from the playlist ({playlist_id})')
 
     else:
@@ -137,11 +142,9 @@ def _get_videos_to_add_count(service: pyt.Client, target_playlist: str, lmt: int
         Number of videos to add (0 if error or already full).
     """
     try:
-        current_count = len(service.playlistItems.list(
-            part=['snippet'],
-            max_results=lmt,
-            playlist_id=target_playlist
-        ).items)
+        current_count = len(
+            service.playlistItems.list(part=['snippet'], max_results=lmt, playlist_id=target_playlist).items
+        )
         return lmt - current_count
 
     except pyt.PyYouTubeException as error:
@@ -180,12 +183,12 @@ def _calculate_allocation(n_add: int, count_a: int, count_b: int) -> tuple[int, 
 
 
 def _transfer_videos(
-        service: pyt.Client,
-        target_playlist: str,
-        source_playlist: str,
-        videos: list[dict],
-        source_name: str,
-        prog_bar: bool
+    service: pyt.Client,
+    target_playlist: str,
+    source_playlist: str,
+    videos: list[dict],
+    source_name: str,
+    prog_bar: bool,
 ) -> None:
     """Transfer videos from source to target playlist.
 
@@ -202,27 +205,17 @@ def _transfer_videos(
 
     if utils.history:
         utils.history.info('%s addition(s) from %s playlist.', len(videos), source_name)
-    add_to_playlist(
-        service,
-        target_playlist,
-        [v['video_id'] for v in videos],
-        prog_bar
-    )
-    del_from_playlist(
-        service,
-        source_playlist,
-        videos,
-        prog_bar
-    )
+    add_to_playlist(service, target_playlist, [v['video_id'] for v in videos], prog_bar)
+    del_from_playlist(service, source_playlist, videos, prog_bar)
 
 
 def fill_release_radar(
-        service: pyt.Client,
-        target_playlist: str,
-        re_listening_id: str,
-        legacy_id: str,
-        lmt: int | None = None,
-        prog_bar: bool = True
+    service: pyt.Client,
+    target_playlist: str,
+    re_listening_id: str,
+    legacy_id: str,
+    lmt: int | None = None,
+    prog_bar: bool = True,
 ) -> None:
     """Fill the Release Radar playlist with videos from re-listening playlists.
 
@@ -251,24 +244,20 @@ def fill_release_radar(
     week_ago = utils.NOW - dt.timedelta(weeks=config.RELISTENING_AGE_WEEKS)
 
     to_re_listen_items = service.playlistItems.list(
-        part=['snippet', 'contentDetails'],
-        playlist_id=re_listening_id,
-        max_results=lmt
+        part=['snippet', 'contentDetails'], playlist_id=re_listening_id, max_results=lmt
     ).items
-    to_re_listen_raw = [{'video_id': item.contentDetails.videoId,
-                         'add_date': dt.datetime.strptime(
-                             item.snippet.publishedAt,
-                             utils.ISO_DATE_FORMAT
-                         ),
-                         'item_id': item.id} for item in to_re_listen_items]
+    to_re_listen_raw = [
+        {
+            'video_id': item.contentDetails.videoId,
+            'add_date': dt.datetime.strptime(item.snippet.publishedAt, utils.ISO_DATE_FORMAT),
+            'item_id': item.id,
+        }
+        for item in to_re_listen_items
+    ]
 
     to_re_listen_fil = [item for item in to_re_listen_raw if item['add_date'] < week_ago]
 
-    legacy_items = service.playlistItems.list(
-        part=['contentDetails'],
-        playlist_id=legacy_id,
-        max_results=lmt
-    ).items
+    legacy_items = service.playlistItems.list(part=['contentDetails'], playlist_id=legacy_id, max_results=lmt).items
     legacy_raw = [{'video_id': item.contentDetails.videoId, 'item_id': item.id} for item in legacy_items]
 
     # Pre-selection with fallback if one source is insufficient
@@ -277,29 +266,15 @@ def fill_release_radar(
 
     # Adjust allocations if one source doesn't have enough content
     if len(addition_leg) < n_add_leg:
-        addition_rel = to_re_listen_fil[:n_add - len(addition_leg)]
+        addition_rel = to_re_listen_fil[: n_add - len(addition_leg)]
 
     elif len(addition_rel) < n_add_rel:
-        addition_leg = legacy_raw[:n_add - len(addition_rel)]
+        addition_leg = legacy_raw[: n_add - len(addition_rel)]
 
     # Transfer videos from sources to target
-    _transfer_videos(
-        service,
-        target_playlist,
-        re_listening_id,
-        addition_rel,
-        'Re-listening',
-        prog_bar
-    )
+    _transfer_videos(service, target_playlist, re_listening_id, addition_rel, 'Re-listening', prog_bar)
 
-    _transfer_videos(
-        service,
-        target_playlist,
-        legacy_id,
-        addition_leg,
-        'Legacy',
-        prog_bar
-    )
+    _transfer_videos(service, target_playlist, legacy_id, addition_leg, 'Legacy', prog_bar)
 
 
 def add_api_fail(service: pyt.Client, prog_bar: bool = True) -> None:
@@ -316,8 +291,9 @@ def add_api_fail(service: pyt.Client, prog_bar: bool = True) -> None:
         if info['failure']:
             videos_to_retry = info['failure'].copy()  # Copy the list before clearing
             if utils.history:
-                utils.history.info('%s addition(s) to %s playlist from previous API failure.',
-                                   len(videos_to_retry), info['name'])
+                utils.history.info(
+                    '%s addition(s) to %s playlist from previous API failure.', len(videos_to_retry), info['name']
+                )
             api_failure[p_id]['failure'] = []  # Clear before retry so add_to_playlist can re-add failures
             file_utils.save_json(str(paths.API_FAILURE_JSON), api_failure)  # Save cleared state
 

--- a/yrt/youtube/playlist.py
+++ b/yrt/youtube/playlist.py
@@ -151,9 +151,8 @@ def _get_videos_to_add_count(service: pyt.Client, target_playlist: str, lmt: int
         if error.status_code == 403:
             if utils.history:
                 utils.history.warning('API quota exceeded.')
-        else:
-            if utils.history:
-                utils.history.warning('Unknown error: %s', error.message)
+        elif utils.history:
+            utils.history.warning('Unknown error: %s', error.message)
         return 0
 
 

--- a/yrt/youtube/stats.py
+++ b/yrt/youtube/stats.py
@@ -155,9 +155,8 @@ def weekly_stats(
         histo_data.loc[histo_data.video_id.isin(id_mask), ['status']] = histo_data.latest_status
         histo_data.drop(columns=['views', 'likes', 'comments', 'latest_status'], inplace=True)
 
-    else:
-        if utils.history:
-            utils.history.info('No change to apply on historical data for following delta: %s week(s)', week_delta)
+    elif utils.history:
+        utils.history.info('No change to apply on historical data for following delta: %s week(s)', week_delta)
 
     # Apply the type Int64 for each feature (necessary for export)
     w_features = [col for col in histo_data.columns if '_w' in col]

--- a/yrt/youtube/stats.py
+++ b/yrt/youtube/stats.py
@@ -5,15 +5,15 @@ import datetime as dt
 from typing import Any
 
 # Third-party
-import isodate  # type: ignore[import-untyped]
+import isodate
 import pandas as pd
-import pyyoutube as pyt  # type: ignore[import-untyped]
+import pyyoutube as pyt
 
 # Local
 from .. import config
 from ..constants import STATUS_DELETED
 from ..exceptions import APIError
-from ..models import PlaylistItem, VideoStats, VideoData, to_dict_list
+from ..models import PlaylistItem, VideoData, VideoStats, to_dict_list
 from . import utils
 from .api import get_videos
 
@@ -41,10 +41,7 @@ def get_stats(service: pyt.Client, videos_list: list[Any], check_shorts: bool = 
         videos_ids = videos_list
 
     # Split tasks in chunks to request a maximum of API_BATCH_SIZE videos at each iteration.
-    batch_size = config.API_BATCH_SIZE
-    videos_chunks = [videos_ids[i:i + min(batch_size, len(videos_ids))] for i in range(0, len(videos_ids), batch_size)]
-
-    for chunk in videos_chunks:
+    for chunk in utils.chunked(videos_ids, config.API_BATCH_SIZE):
         try:
             request = get_videos(service=service, videos_list=chunk)
 
@@ -58,7 +55,7 @@ def get_stats(service: pyt.Client, videos_list: list[Any], check_shorts: bool = 
                     duration=isodate.parse_duration(getattr(item.contentDetails, 'duration', 'PT0S') or 'PT0S').seconds,
                     is_shorts=utils.is_shorts(video_id=item.id) if check_shorts else None,
                     live_status=item.snippet.liveBroadcastContent,
-                    latest_status=item.status.privacyStatus
+                    latest_status=item.status.privacyStatus,
                 )
                 for item in request
             ]
@@ -66,7 +63,7 @@ def get_stats(service: pyt.Client, videos_list: list[Any], check_shorts: bool = 
         except pyt.error.PyYouTubeException as api_error:
             if utils.history:
                 utils.history.error(api_error.message)
-            raise APIError(f'API error while getting stats: {api_error.message}')
+            raise APIError(f'API error while getting stats: {api_error.message}') from api_error
 
     validated = [video.video_id for video in items]
     missing = [vid_id for vid_id in videos_ids if vid_id not in validated]
@@ -80,7 +77,7 @@ def get_stats(service: pyt.Client, videos_list: list[Any], check_shorts: bool = 
             duration=None,
             is_shorts=None,
             live_status=None,
-            latest_status=STATUS_DELETED
+            latest_status=STATUS_DELETED,
         )
         for item_id in missing
     ]
@@ -109,8 +106,7 @@ def add_stats(service: pyt.Client, playlist_items: list[PlaylistItem]) -> pd.Dat
 
     # Merge PlaylistItem + VideoStats into VideoData
     video_data_list = [
-        VideoData.from_playlist_item_and_stats(item, stats_by_id[item.video_id])
-        for item in playlist_items
+        VideoData.from_playlist_item_and_stats(item, stats_by_id[item.video_id]) for item in playlist_items
     ]
 
     # Convert to DataFrame
@@ -118,10 +114,7 @@ def add_stats(service: pyt.Client, playlist_items: list[PlaylistItem]) -> pd.Dat
 
 
 def weekly_stats(
-        service: pyt.Client,
-        histo_data: pd.DataFrame,
-        week_delta: int,
-        ref_date: dt.datetime = dt.datetime.now(dt.timezone.utc)
+    service: pyt.Client, histo_data: pd.DataFrame, week_delta: int, ref_date: dt.datetime | None = None
 ) -> pd.DataFrame:
     """Add weekly statistics to historical data retrieved from YouTube for each run.
 
@@ -129,11 +122,14 @@ def weekly_stats(
         service: A Python YouTube Client.
         histo_data: Data with statistics retrieved throughout the weeks.
         week_delta: How far we should get stats for videos (1, 4, 13 or 26 weeks).
-        ref_date: A reference date (midnight UTC by default).
+        ref_date: A reference date (current time in UTC by default, evaluated per call).
 
     Returns:
         Historical data enhanced with new statistics.
     """
+    if ref_date is None:
+        ref_date = dt.datetime.now(dt.UTC)
+
     # Get the date from "x week ago"
     x_week_ago = ref_date.replace(hour=0, minute=0, second=0, microsecond=0) - dt.timedelta(weeks=week_delta)
 

--- a/yrt/youtube/utils.py
+++ b/yrt/youtube/utils.py
@@ -2,24 +2,24 @@
 
 # Standard library
 import datetime as dt
+import itertools
 import re
+from collections.abc import Sequence
 from typing import Any
 
 # Third-party
-import pyyoutube as pyt  # type: ignore[import-untyped]
+import pyyoutube as pyt
 import requests
 import tzlocal
 
 # Local
-from .. import config
-from .. import file_utils
-from .. import paths
+from .. import config, file_utils, paths
 from ..constants import (
-    TRANSIENT_ERRORS,
-    PERMANENT_ERRORS,
-    QUOTA_ERRORS,
     ISO_DATE_FORMAT,
     LOG_DATE_FORMAT,
+    PERMANENT_ERRORS,
+    QUOTA_ERRORS,
+    TRANSIENT_ERRORS,
 )
 from ..exceptions import APIError
 
@@ -49,7 +49,7 @@ def last_exe_date() -> dt.datetime:
         Last execution date, or 24 hours ago if log is missing/empty.
     """
     try:
-        with open(paths.LAST_EXE_LOG, 'r', encoding='utf8') as log_file:
+        with open(paths.LAST_EXE_LOG, encoding='utf8') as log_file:
             lines = log_file.readlines()
             if not lines:
                 # Empty file - default to 24 hours ago (daily workflow)
@@ -68,13 +68,26 @@ def last_exe_date() -> dt.datetime:
         return dt.datetime.now(tz=tzlocal.get_localzone()) - dt.timedelta(days=1)
 
 
+def chunked[T](sequence: Sequence[T], size: int) -> list[list[T]]:
+    """Split a sequence into consecutive chunks of at most size items.
+
+    Args:
+        sequence: The sequence to split.
+        size: Maximum number of items per chunk (must be >= 1).
+
+    Returns:
+        A list of chunks, each a list with at most size items.
+    """
+    return [list(batch) for batch in itertools.batched(sequence, size)]
+
+
 # Module-level state (calculated at import time)
 ADD_ON = file_utils.load_json(str(paths.ADD_ON_JSON))
 NOW = dt.datetime.now(tz=tzlocal.get_localzone())
 LAST_EXE = last_exe_date()
 
 # Logger placeholder - will be set by __init__.py
-history = None  # type: ignore[assignment]
+history: Any = None
 
 
 def set_logger(logger: Any) -> None:
@@ -98,9 +111,7 @@ def is_shorts(video_id: str) -> bool:
     """
     try:
         response = requests.head(
-            f'https://www.youtube.com/shorts/{video_id}',
-            timeout=config.NETWORK_TIMEOUT,
-            allow_redirects=False
+            f'https://www.youtube.com/shorts/{video_id}', timeout=config.NETWORK_TIMEOUT, allow_redirects=False
         )
         return response.status_code == 200
 
@@ -148,15 +159,12 @@ def sort_db(service: pyt.Client, log: bool = True) -> None:
         information = []
 
         # Split task in chunks to request on a maximum of API_BATCH_SIZE channels at each iteration.
-        batch_size = config.API_BATCH_SIZE
-        channels_chunks = [_channel_list[i:i + min(batch_size, len(_channel_list))]
-                           for i in range(0, len(_channel_list), batch_size)]
-
-        for chunk in channels_chunks:
+        for chunk in chunked(_channel_list, config.API_BATCH_SIZE):
             try:
                 # Request channels
-                request = _service.channels.list(part=['snippet'], channel_id=chunk,
-                                                 max_results=config.API_BATCH_SIZE).items
+                request = _service.channels.list(
+                    part=['snippet'], channel_id=chunk, max_results=config.API_BATCH_SIZE
+                ).items
 
                 # Extract upload playlists, channel names and their ID.
                 information += [{'title': an_item.snippet.title, 'id': an_item.id} for an_item in request]
@@ -164,19 +172,18 @@ def sort_db(service: pyt.Client, log: bool = True) -> None:
             except pyt.error.PyYouTubeException as api_error:
                 if log and history:
                     history.error(api_error.message)
-                raise APIError(f'API error while sorting database: {api_error.message}')
+                raise APIError(f'API error while sorting database: {api_error.message}') from api_error
 
         # Sort channels' name by alphabetical order
         information = sorted(information, key=lambda dic: dic['title'].lower())
-        ids_only = [info['id'] for info in information]  # Get channel IDs only
-
-        return ids_only
+        return [info['id'] for info in information]  # Get channel IDs only
 
     channels_db = file_utils.load_json(str(paths.POCKET_TUBE_JSON))
 
-    categories = [db_keys for db_keys in channels_db.keys() if 'ysc' not in db_keys]  # Get PT categories
-    db_sorted = {category: get_channels(_service=service, _channel_list=channels_db[category])
-                 for category in categories}
+    categories = [db_keys for db_keys in channels_db if 'ysc' not in db_keys]  # Get PT categories
+    db_sorted = {
+        category: get_channels(_service=service, _channel_list=channels_db[category]) for category in categories
+    }
 
     for category in categories:  # Rewrite categories in the dict object associated with the PT JSON file
         channels_db[category] = db_sorted[category]


### PR DESCRIPTION
## Summary

Brings two streams of work from `dev` into `main`:

1. **Branch reorganization** — a dedicated `run` branch for daily execution so `main` stays a clean code
   reference, with monthly consolidation of run logs back into `main`.
2. **Codebase-wide quality pass** — a much stricter ruff/mypy configuration, the resulting cleanups, and
   several real bug fixes uncovered along the way.

## Branch reorganization

Until now, the daily process committed its execution reports (`stats.csv`, history and last-execution logs)
straight to `main`, burying the actual code history under daily `log:` commits. The new model separates the
two concerns:

- **`main`** — clean code reference. Receives code through `dev` and a single squashed log commit per month.
- **`run`** — long-lived execution branch. The daily process runs here and accumulates its daily reports.
- **`dev`** — integration branch for code work.

The guiding invariant is that **`main` is always an ancestor of `run`**, which keeps every automated merge
conflict-free.

**Daily workflow (`main_workflow.yml`):**

- Checks out and pushes to `run` instead of `main`.
- Syncs the latest code from `main` before each run, keeping execution on up-to-date code while preserving the
  branch's accumulated data on the rare conflict.

**Monthly workflow (`monthly_consolidation.yml`, new):**

- On the 1st of each month, squashes the month's run reports into a single
  `log: Monthly execution report (YYYY-MM).` commit on `main`.
- Resets `run` back onto `main` to restore the invariant.

> The `run` branch has already been created and pushed. The workflow changes only take effect once they reach
> `main`, since scheduled GitHub Actions run from the default branch.

## Code quality & configuration

Expands the ruff ruleset (pyflakes, pycodestyle, isort, pyupgrade, bugbear, simplify, pydocstyle, naming,
annotations, security/bandit, return, type-checking, ...) with a 120-character line length, Google docstring
convention, first-party isort grouping and single-quote formatting. Tightens mypy with stricter flags
(`disallow_untyped_defs`, `no_implicit_optional`, `warn_unused_ignores`, ...). Adds scoped per-file ignores for
tests, maintenance scripts and local-mode console output. The whole codebase and test suite were reformatted
and annotated to satisfy the new rules.

Additionally adds the `PLR` (pylint refactor) ruleset to catch useless-return (`PLR1711`) and similar issues
locally — the class of issue resolved here by DeepSource Autofix. `PLR2004` (magic values) and `PLR0913` (too
many arguments) are ignored as high-noise or inherent to the API-wrapper design; `PLR5501` (`else: if` → `elif`)
findings were fixed.

## Fixes & improvements

- **Weekly stats reference date** was frozen at import time; it is now evaluated per call so statistics land on
  the correct interval.
- **Credential validation** now raises an explicit `CredentialsError` instead of relying on an `assert`
  (which is stripped under optimized runs).
- **Exception chaining** (`raise ... from`) added so error provenance is preserved.
- **Shared batching helper** replaces hand-rolled slice batching across the YouTube package, removing duplicated
  chunking logic.
- **`python-dateutil`** is now declared as a direct dependency (previously only pulled in transitively).
- Reporting notebook renders DataFrames as trailing expressions for proper table output.
- Removed stale suppressions and import-section header normalization across modules.
- **Maintenance scripts** (`archive_data.py`, `sort_db.py`) no longer trigger "module level import not at top of
  file": `pandas`/`dateutil` move above the logging bootstrap, and `yrt` imports are done locally inside the
  functions that use them (after the `YRT_NO_LOGGING` / `sys.path` setup) — no suppression comments.

## Documentation

- README repository-structure tree documents the purpose of every top-level directory with aligned inline comments.
- New **Branches** section documenting the `main` / `run` / `dev` model.
- Badges revamped: added `uv`, `Ruff` and a status badge, switched the CI badge to the shields.io `flat-square`
  style, and bumped the Python badge to `3.12+`.

## Validation steps before merge

- [x] DeepSource Health-Check OK (no regression)
- [x] Tests/Coverage CI OK
- [x] Human review completed (post-changes made by DeepSource or assisted tools)
