### PR TITLE
ci: push monthly consolidation as admin (PAT) to satisfy main ruleset

### DIFF
--- a/.github/workflows/monthly_consolidation.yml
+++ b/.github/workflows/monthly_consolidation.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.PAT }}
 
       - id: consolidate
         name: Squash run into main and reset run


### PR DESCRIPTION
## What

`monthly_consolidation.yml` now checks out with `token: ${{ secrets.PAT }}` so its **direct push to `main`** is authenticated as the repo admin.

## Why

The `main` branch ruleset was upgraded (require-PR squash-only + linear history + thread-resolution + required `test` check). Those rules **also block direct pushes**, and the monthly consolidation job pushes straight to `main` as `github-actions[bot]` — which GitHub will **not** allow as a ruleset bypass actor on a user-owned repo. Authenticating as the admin (PAT) lets the monthly push bypass via the admin role, keeping the `run` → `main` squash automation working.

## Propagation

Once merged, the daily `main_workflow.yml` `sync-code` step carries this into `run` automatically — no manual step needed.

## Notes

- Requires `secrets.PAT` to have `repo` scope and admin on the repo (already used elsewhere in this workflow's env).
- Companion change (already applied via GitHub API, not in this diff): `main` ruleset upgrade + new `dev-protection` ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)