### PR TITLE
feat(ci): adopt feat → dev → main fast-forward branch model

### DIFF
--- a/.github/workflows/monthly_consolidation.yml
+++ b/.github/workflows/monthly_consolidation.yml
@@ -36,3 +36,6 @@ jobs:
           git diff --staged --quiet || git commit -m "log: Monthly execution report (${MONTH})."
           git push origin main
           git push --force origin main:run
+          # Keep dev fast-forwardable to main: advance dev to the monthly commit.
+          # A non-fast-forward (unshipped dev work exists) is rejected harmlessly.
+          git push origin main:dev || echo "dev has unshipped work; rebase dev onto main before next ship"

--- a/.github/workflows/ship.yml
+++ b/.github/workflows/ship.yml
@@ -1,0 +1,31 @@
+name: YTB Tracker - Ship dev to main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ship:
+    name: fast-forward-main-to-dev
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - id: git-checkout
+        name: Checkout main branch
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+
+      - id: ship
+        name: Fast-forward main to dev
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions"
+          git fetch origin dev main
+          git checkout main
+          git merge --ff-only origin/dev
+          git push origin main

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test:


### PR DESCRIPTION

## Summary

Moves the integration model from squash-merging `dev → main` to a `feat → dev → main` flow where `dev` ships to `main` by **fast-forward**. The squash now happens once, at `feat → dev`, so `main` keeps its per-feature history while `dev` stops diverging from `main` after every merge — removing the per-cycle `reset --hard` ritual. The quality gate relocates from `main` to `dev`, which becomes the protected integration branch.

This PR contains the CI/workflow side of that change. The `dev` ruleset update and the `feat → dev → main` docs in `CLAUDE.md` are applied out-of-band (see *Out of scope* below).

## Changes

- **Add `ship.yml`** — a manual (`workflow_dispatch`) job that fast-forwards `main` to `dev`. It authenticates with `secrets.PAT` so the direct push is admin-attributed and bypasses the `main` ruleset, and uses `git merge --ff-only` so it refuses to create a merge commit and fails loudly if `dev` was not resynced after the monthly consolidation.
- **`test-coverage.yml`** — also trigger on PRs targeting `dev`, so the required `test` check now gates `feat → dev` merges (the gate that previously lived only on `main`).
- **`monthly_consolidation.yml`** — after consolidating `run` into `main`, carry the new monthly log commit back into `dev` with a non-force `main:dev` push so `dev` stays fast-forwardable onto `main`. The push is rejected harmlessly when `dev` has unshipped work, leaving that resync to the operator.

## How shipping works after this

1. Branch `feat/*` off `dev`, open a squash PR into `dev` (gated by `test`).
2. Run `ship.yml` to fast-forward `main` to `dev`; `main` keeps per-feature commits and ends equal to `dev`.
3. The only residual `dev`/`main` divergence is the monthly log commit, which `monthly_consolidation.yml` carries back into `dev` automatically when `dev` is clean.

## Out of scope (applied separately)

The `dev-protection` ruleset must be promoted to the real gate (require PR + `test` + linear history, squash-only) via the GitHub rulesets API — not changeable from a workflow file.

## Validation steps before merge

- [x] DeepSource Health-Check OK (no regression)
- [x] Tests/Coverage CI OK
- [x] Human review completed (post-changes made by DeepSource or assisted tools)
