### PR TITLE
fix(ci): target dependabot PRs at `dev` instead of `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "monthly"
       time: "09:00"
@@ -18,6 +19,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "monthly"
       time: "09:00"

--- a/_docs/IMPROVEMENTS-2026.md
+++ b/_docs/IMPROVEMENTS-2026.md
@@ -161,7 +161,7 @@ checking benefits.
 - 26 comprehensive unit tests added
 - Zero regressions (100 tests passing)
 
-### 5. Extract VideoRouter Class from dest_playlist()
+### 5. Extract VideoRouter Class from dest_playlist ()
 
 **Location:** `yrt/main.py:213-280`
 
@@ -656,10 +656,10 @@ class YouTubeService(Protocol):
 
 **Status:** Accepted (documented limitation, no action needed)
 
-**Issue:** The daily run uses native GitHub Actions timezone support
-(`cron: "0 0 * * *"` + `timezone: "America/Los_Angeles"`, shipped March 2026). The config is correct and the job fires
-once per calendar day, but the actual dispatch is routinely **several hours late**: midnight Pacific maps to 07:00 UTC
-(PDT) / 08:00 UTC (PST), yet runs land mid-morning UTC (~09:00-13:00Z). This is inherent to GitHub's shared `schedule:`
+**Issue:** The daily run uses native GitHub Actions timezone support (`cron: "0 0 * * *"` +
+`timezone: "America/Los_Angeles"`, shipped March 2026). The config is correct and the job fires once per calendar day,
+but the actual dispatch is routinely **several hours late**: midnight Pacific maps to 07:00 UTC (PDT) / 08:00 UTC (PST),
+yet runs land mid-morning UTC (~09:00-13:00Z). This is inherent to GitHub's shared `schedule:`
 infrastructure — a hand-written UTC cron lags identically — and is confirmed expected behaviour, not a bug (community
 discussion #191400).
 
@@ -693,23 +693,23 @@ The schedule is healthy as long as it fires once per calendar day.
 
 | Module                    | Coverage | Status         |
 |---------------------------|----------|----------------|
-| `yrt/__init__.py`         | 100%     | ✅ Complete     |
-| `yrt/config.py`           | 100%     | ✅ Complete     |
-| `yrt/constants.py`        | 100%     | ✅ Complete     |
-| `yrt/exceptions.py`       | 100%     | ✅ Complete     |
-| `yrt/logging_utils.py`    | 100%     | ✅ Complete     |
-| `yrt/models.py`           | 100%     | ✅ Complete     |
-| `yrt/paths.py`            | 100%     | ✅ Complete     |
-| `yrt/router.py`           | 95%      | ✅ Complete     |
+| `yrt/__init__.py`         | 100%     | ✅ Complete    |
+| `yrt/config.py`           | 100%     | ✅ Complete    |
+| `yrt/constants.py`        | 100%     | ✅ Complete    |
+| `yrt/exceptions.py`       | 100%     | ✅ Complete    |
+| `yrt/logging_utils.py`    | 100%     | ✅ Complete    |
+| `yrt/models.py`           | 100%     | ✅ Complete    |
+| `yrt/paths.py`            | 100%     | ✅ Complete    |
+| `yrt/router.py`           | 95%      | ✅ Complete    |
 | `yrt/file_utils.py`       | 76%      | 🔸 Needs work  |
-| `yrt/youtube/__init__.py` | 100%     | ✅ Complete     |
+| `yrt/youtube/__init__.py` | 100%     | ✅ Complete    |
 | `yrt/youtube/utils.py`    | 58%      | 🔸 Needs work  |
 | `yrt/youtube/stats.py`    | 23%      | ⚠️ Low         |
 | `yrt/youtube/api.py`      | 20%      | ⚠️ Low         |
 | `yrt/youtube/auth.py`     | 17%      | ⚠️ Low         |
 | `yrt/youtube/playlist.py` | 15%      | ⚠️ Low         |
 | `yrt/youtube/cleanup.py`  | 12%      | ⚠️ Low         |
-| `yrt/main.py`             | 0%       | ❌ Not covered  |
+| `yrt/main.py`             | 0%       | ❌ Not covered |
 | `yrt/analytics.py`        | 0%       | 🚫 Placeholder |
 | `yrt/_sandbox.py`         | 0%       | 🚫 Dev only    |
 
@@ -725,7 +725,7 @@ The schedule is healthy as long as it fires once per calendar day.
 | `yrt/exceptions.py`        | Add context attributes             |
 | `yrt/analytics.py`         | Remove or mark as placeholder      |
 | `_scripts/archive_data.py` | Use specific exceptions            |
-| `_tests/conftest.py`       | ✅ Add YRT_NO_LOGGING isolation     |
+| `_tests/conftest.py`       | ✅ Add YRT_NO_LOGGING isolation    |
 | `_tests/test_main.py`      | Implement 20 skipped tests         |
 | `_tests/test_youtube.py`   | Implement duration parsing tests   |
 
@@ -733,20 +733,20 @@ The schedule is healthy as long as it fires once per calendar day.
 
 | File                           | Purpose                  | Status                         |
 |--------------------------------|--------------------------|--------------------------------|
-| `yrt/logging_utils.py`         | Shared logger factory    | ✅ Created                      |
-| `yrt/router.py`                | Video routing logic      | ✅ Created                      |
-| `yrt/constants.py`             | Magic strings/numbers    | ✅ Created                      |
-| `yrt/youtube/__init__.py`      | Package exports          | ✅ Created                      |
-| `yrt/youtube/auth.py`          | Authentication functions | ✅ Created                      |
-| `yrt/youtube/api.py`           | Core API calls           | ✅ Created                      |
-| `yrt/youtube/stats.py`         | Statistics management    | ✅ Created                      |
-| `yrt/youtube/playlist.py`      | Playlist operations      | ✅ Created                      |
-| `yrt/youtube/cleanup.py`       | Cleanup operations       | ✅ Created                      |
+| `yrt/logging_utils.py`         | Shared logger factory    | ✅ Created                     |
+| `yrt/router.py`                | Video routing logic      | ✅ Created                     |
+| `yrt/constants.py`             | Magic strings/numbers    | ✅ Created                     |
+| `yrt/youtube/__init__.py`      | Package exports          | ✅ Created                     |
+| `yrt/youtube/auth.py`          | Authentication functions | ✅ Created                     |
+| `yrt/youtube/api.py`           | Core API calls           | ✅ Created                     |
+| `yrt/youtube/stats.py`         | Statistics management    | ✅ Created                     |
+| `yrt/youtube/playlist.py`      | Playlist operations      | ✅ Created                     |
+| `yrt/youtube/cleanup.py`       | Cleanup operations       | ✅ Created                     |
 | `yrt/youtube/models.py`        | Dataclasses and enums    | Deferred (using yrt/models.py) |
 | `yrt/youtube/retry.py`         | Retry decorator          | Pending                        |
-| `yrt/youtube/utils.py`         | Utilities                | ✅ Created                      |
-| `_tests/test_router.py`        | Router unit tests        | ✅ Created                      |
-| `_tests/test_constants.py`     | Constants unit tests     | ✅ Created                      |
+| `yrt/youtube/utils.py`         | Utilities                | ✅ Created                     |
+| `_tests/test_router.py`        | Router unit tests        | ✅ Created                     |
+| `_tests/test_constants.py`     | Constants unit tests     | ✅ Created                     |
 | `_tests/fixtures/error_*.json` | Error response fixtures  | Pending                        |
 
 ## Implementation Order


### PR DESCRIPTION
## Summary

Dependabot had no `target-branch` configured, so it defaulted to the repository's default branch and opened its PRs against `main`. Under the `feat → dev → main` model this is the wrong entry point: `main` should only advance by fast-forward from `dev` or by the monthly log commit, so dependency PRs merging directly into `main` would recreate the `dev`/`main` divergence the model was designed to remove. This pins both ecosystems to `dev`, the protected integration branch where features are meant to enter.

## Changes

- **`.github/dependabot.yml`** — add `target-branch: "dev"` to both the `uv` (Python dependencies) and `github-actions` update configurations, so future dependency PRs are opened against `dev` and branched off it.
- **`_docs/IMPROVEMENTS-2026.md`** — incidental editor reformatting picked up in the same commit: table column realignment around emoji status markers and one paragraph rewrap. No content change.

## Notes

Dependabot reads its configuration from the default branch only, so this change takes effect once it has been shipped to `main`. The two dependency PRs that were already open against `main` have been retargeted to `dev` out-of-band; because `dev` and `main` were at the same commit, their diffs were unaffected.

No change is needed to the required status check: `test-coverage.yml` already triggers on pull requests targeting `dev`, so dependency PRs stay gated exactly as feature PRs are.

## Validation steps before merge

- [ ] DeepSource Health-Check OK (no regression)
- [ ] Tests/Coverage CI OK
- [ ] Human review completed (post-changes made by DeepSource or assisted tools)
